### PR TITLE
Name suggestions: add prefix to Num to quanitities; add suffix Set to…

### DIFF
--- a/DAGRider_Spec.tla
+++ b/DAGRider_Spec.tla
@@ -1,44 +1,44 @@
 --------------------------- MODULE DAGRider_Spec ---------------------------
 EXTENDS Sequences, FiniteSets, Integers, TLAPS, TLC
 
-CONSTANT n_DAG,
-         w_DAG, 
-         Blocks,
-         choose_leader(_) 
+CONSTANT NumProcessors,
+         NumWaves, 
+         BlockSet,
+         ChooseLeader(_) 
          
-ASSUME nAssumption == n_DAG \in Nat\{0}
-ASSUME wAssumption == w_DAG \in Nat\{0}
+ASSUME NumProcessorAsm == NumProcessors \in Nat\{0}
+ASSUME NumWaveAsm == NumWaves \in Nat\{0}
 
 ----------------------------------------------------------------------------
 
-f == (n_DAG-1) \div 3 
+NumFaultyProcessors == (NumProcessors-1) \div 3 
 
-Rounds == 0..(4*w_DAG)
+RoundSet == 0..(4*NumWaves)
 
-Waves == 1..w_DAG
+WaveSet == 1..NumWaves
 
-Proc == 1..n_DAG
-ASSUME ProcAssumption == "History" \notin Proc
+ProcessorSet == 1..NumProcessors
+ASSUME ProcSetAsm == "History" \notin ProcessorSet
 
 RECURSIVE vertices_in(_), vertices_till(_), Vertices
 
 dummy_vertex(p) == [round |-> 0, source |-> p, block |-> "Empty", edges |-> {}]
-DummyVertices == {dummy_vertex(p) : p \in Proc}
+DummyVertices == {dummy_vertex(p) : p \in ProcessorSet}
 
 vertices_in(r) == IF r = 0 
                  THEN DummyVertices
-                 ELSE [round : {r}, source : Proc, Block : Blocks, Neighbours : SUBSET(vertices_in(r-1))]
+                 ELSE [round : {r}, source : ProcessorSet, Block : BlockSet, Neighbours : SUBSET(vertices_in(r-1))]
                
 vertices_till(r) == IF r = 0
                    THEN vertices_in(r)
                    ELSE vertices_in(r) \cup vertices_till(r-1)
                    
-Vertices == vertices_till(4*w_DAG)
+Vertices == vertices_till(4*NumWaves)
 
-TaggedVertices == [sender : Proc, inRound : Rounds, vertex : Vertices]
+TaggedVertices == [sender : ProcessorSet, inRound : RoundSet, vertex : Vertices]
 
 nil_vertex(p,r) == [round |-> r, source |-> p, block |-> "Nil", edges |-> {}]
-NilVertices == {nil_vertex(p, r) : p \in Proc, r \in Rounds}
+NilVertices == {nil_vertex(p, r) : p \in ProcessorSet, r \in RoundSet}
 
 ----------------------------------------------------------------------------
 
@@ -46,28 +46,28 @@ VARIABLE blocksToPropose, DAGround, DAG, bcastNetwork, bcastRecord, buffer, reco
 
 ----------------------------------------------------------------------------
 
-Chain  == INSTANCE LeaderConsensus_Verification WITH w_DAG <- w_DAG, n_DAG <- n_DAG,  record <- record, decidedRefWave <- decidedRefWave, 
+Chain  == INSTANCE LeaderConsensus_Verification WITH NumWaves <- NumWaves, NumProcessors <- NumProcessors,  record <- record, decidedRefWave <- decidedRefWave, 
                                                      leaderSeq <- leaderSeq, commitWithRef <- commitWithRef
 
 ----------------------------------------------------------------------------
 
-TypeOK == /\ blocksToPropose \in [Proc -> Seq(Blocks)]
-          /\ DAGround \in [Proc -> Rounds]
-          /\ bcastNetwork \in [Proc \cup {"History"} ->SUBSET(TaggedVertices)]
-          /\ bcastRecord \in [Proc -> [Rounds -> BOOLEAN]]
-          /\ buffer \in [Proc -> SUBSET(Vertices)]
-          /\ DAG \in [Proc -> [Rounds  -> [Proc -> Vertices \cup NilVertices]]]
+TypeOK == /\ blocksToPropose \in [ProcessorSet -> Seq(BlockSet)]
+          /\ DAGround \in [ProcessorSet -> RoundSet]
+          /\ bcastNetwork \in [ProcessorSet \cup {"History"} ->SUBSET(TaggedVertices)]
+          /\ bcastRecord \in [ProcessorSet -> [RoundSet -> BOOLEAN]]
+          /\ buffer \in [ProcessorSet -> SUBSET(Vertices)]
+          /\ DAG \in [ProcessorSet -> [RoundSet  -> [ProcessorSet -> Vertices \cup NilVertices]]]
 
 TypeOK_System == TypeOK /\ Chain!TypeOK
 
 ----------------------------------------------------------------------------
 
-Init == /\ blocksToPropose = [p \in Proc |-> <<>> ]
-        /\ DAGround = [p \in Proc |-> 0]
-        /\ bcastNetwork = [p \in Proc \cup {"History"} |-> {}]
-        /\ bcastRecord  = [p \in Proc |-> [ r \in Rounds |-> IF r = 0 THEN TRUE ELSE FALSE ]]
-        /\ buffer = [p \in Proc |-> {}]
-        /\ DAG = [p \in Proc |-> [r \in Rounds  |-> [q \in Proc |-> IF r = 0 THEN dummy_vertex(q) ELSE nil_vertex(q,r)]]]
+Init == /\ blocksToPropose = [p \in ProcessorSet |-> <<>> ]
+        /\ DAGround = [p \in ProcessorSet |-> 0]
+        /\ bcastNetwork = [p \in ProcessorSet \cup {"History"} |-> {}]
+        /\ bcastRecord  = [p \in ProcessorSet |-> [ r \in RoundSet |-> IF r = 0 THEN TRUE ELSE FALSE ]]
+        /\ buffer = [p \in ProcessorSet |-> {}]
+        /\ DAG = [p \in ProcessorSet |-> [r \in RoundSet  |-> [q \in ProcessorSet |-> IF r = 0 THEN dummy_vertex(q) ELSE nil_vertex(q,r)]]]
         /\ Chain!Init
 
 ----------------------------------------------------------------------------
@@ -82,27 +82,27 @@ path(u,v) == IF u = v
 
 added_vertices(p,r) == {v \in Vertices : v.round = r /\ DAG[p][r][v.source] = v}
                    
-\*choose_leader(w) == (w % n_DAG) + 1
+\*ChooseLeader(w) == (w % NumProcessors) + 1
 
-wave_vertex_leader(p, w) == DAG[p][4*w-3][choose_leader(w)]
+wave_vertex_leader(p, w) == DAG[p][4*w-3][ChooseLeader(w)]
 
-waves_with_paths(p,v) == {w \in Waves : path(v,wave_vertex_leader(p, w))}                          
+waves_with_paths(p,v) == {w \in WaveSet : path(v,wave_vertex_leader(p, w))}                          
 
 create_new_vertex(p, r) == [round |-> r, source |-> p, block |-> Head(blocksToPropose[p]), edges |-> added_vertices(p,r-1)]
 
 bcast(p, r, v) == IF bcastRecord[p][r] = FALSE 
                   THEN /\ bcastRecord' = [bcastRecord EXCEPT ![p][r] = TRUE]
-                       /\ bcastNetwork' = [q \in Proc \cup {"History"} |-> bcastNetwork[q] \cup {[sender |-> p, inRound |-> r, vertex |-> v]}]
+                       /\ bcastNetwork' = [q \in ProcessorSet \cup {"History"} |-> bcastNetwork[q] \cup {[sender |-> p, inRound |-> r, vertex |-> v]}]
                   ELSE UNCHANGED <<bcastNetwork, bcastRecord>>
                   
-wave_ready(p, w) == IF DAG[p][4*w-3][wave_vertex_leader(p, w)] \in Vertices /\ \E Q \in SUBSET(added_vertices(p,4*w)): Cardinality(Q) > 2*f /\ \A u \in Q : path(u, wave_vertex_leader(p, w))
+wave_ready(p, w) == IF DAG[p][4*w-3][wave_vertex_leader(p, w)] \in Vertices /\ \E Q \in SUBSET(added_vertices(p,4*w)): Cardinality(Q) > 2NumFaultyProcessors /\ \A u \in Q : path(u, wave_vertex_leader(p, w))
                     THEN Chain!update_decidedRefWave(p, w)
                     ELSE UNCHANGED Chain!vars 
 
 ----------------------------------------------------------------------------
 
-next_round(p) == /\ DAGround[p]+1 \in Rounds
-                 /\ Cardinality(added_vertices(p,DAGround[p])) > 2*f
+next_round(p) == /\ DAGround[p]+1 \in RoundSet
+                 /\ Cardinality(added_vertices(p,DAGround[p])) > 2NumFaultyProcessors
                  /\ blocksToPropose[p] # <<>>
                  /\ bcast(p, DAGround[p]+1, create_new_vertex(p,DAGround[p]+1))
                  /\ DAGround' = [DAGround EXCEPT ![p] = DAGround[p]+1]
@@ -117,7 +117,7 @@ propose(p,b) == /\ blocksToPropose' = [blocksToPropose EXCEPT ![p] = Append(bloc
 recieve_vertex(p, q, r, v) == /\ [sender |-> q, inRound |-> r, vertex |-> v] \in bcastNetwork[p]
                               /\ v.source = q 
                               /\ v.round = r
-                              /\ Cardinality(v.edges) > 2*f
+                              /\ Cardinality(v.edges) > 2NumFaultyProcessors
                               /\ buffer' = [buffer EXCEPT ![p] = buffer[p] \cup {v}]
                               /\ bcastNetwork' = [bcastNetwork EXCEPT ![p] = bcastNetwork[p] \ {[sender |-> q, inRound |-> r, vertex |-> v]}]
                               /\ UNCHANGED Chain!vars
@@ -128,12 +128,12 @@ add_vertex(p,v) == /\ v \in buffer[p]
                    /\ DAG[p][v.round][v.source] = nil_vertex(v.source, v.round)
                    /\ v.edges \in added_vertices(p, v.round -1)
                    /\ DAG'= [DAG EXCEPT ![p][v.round][v.source] = v]
-                   /\ IF v.round % 4 = 1 /\ v.source = choose_leader((v.round \div 4)+1) THEN Chain!update_record(p,(v.round \div 4)+1, waves_with_paths(p,v)) ELSE UNCHANGED Chain!vars
+                   /\ IF v.round % 4 = 1 /\ v.source = ChooseLeader((v.round \div 4)+1) THEN Chain!update_record(p,(v.round \div 4)+1, waves_with_paths(p,v)) ELSE UNCHANGED Chain!vars
                    /\ UNCHANGED <<blocksToPropose, DAGround, bcastNetwork, bcastRecord, buffer>>
 
 ----------------------------------------------------------------------------
 
-Next == \E p \in Proc, r \in Rounds, v \in Vertices, b \in Blocks: \E q \in Proc\{p} : \/ propose(p,b)
+Next == \E p \in ProcessorSet, r \in RoundSet, v \in Vertices, b \in BlockSet: \E q \in ProcessorSet\{p} : \/ propose(p,b)
                                                                                        \/ next_round(p)
                                                                                        \/ recieve_vertex(p, q, r, v)
                                                                                        \/ add_vertex(p,v)
@@ -146,17 +146,17 @@ Spec == Init /\ [][Next]_vars
 
 ----------------------------------------------------------------------------
 
-DAGConsistency == \A p,q \in Proc, r \in Rounds, o \in Proc: r # 0 /\ DAG[p][r][o] \in Vertices /\ DAG[q][r][o] \in Vertices => DAG[p][r][o] = DAG[q][r][o]
-ChainConsistancy == \A p,q \in Proc : decidedRefWave[p] <= decidedRefWave[q] => Chain!IsPrefix(leaderSeq[p].current, leaderSeq[q].current)
-ChainMonotonicity == \A p \in Proc : Chain!IsPrefix(leaderSeq[p].last, leaderSeq[p].current)
+DAGConsistency == \A p,q \in ProcessorSet, r \in RoundSet, o \in ProcessorSet: r # 0 /\ DAG[p][r][o] \in Vertices /\ DAG[q][r][o] \in Vertices => DAG[p][r][o] = DAG[q][r][o]
+ChainConsistancy == \A p,q \in ProcessorSet : decidedRefWave[p] <= decidedRefWave[q] => Chain!IsPrefix(leaderSeq[p].current, leaderSeq[q].current)
+ChainMonotonicity == \A p \in ProcessorSet : Chain!IsPrefix(leaderSeq[p].last, leaderSeq[p].current)
 
 ----------------------------------------------------------------------------
 
-Invariant1 == \A p,q \in Proc, r \in Rounds : r # 0 /\ DAG[p][r][q] \in Vertices => DAG[p][r][q] \in buffer[p] 
+Invariant1 == \A p,q \in ProcessorSet, r \in RoundSet : r # 0 /\ DAG[p][r][q] \in Vertices => DAG[p][r][q] \in buffer[p] 
 Invariant2 == \A m \in bcastNetwork["History"]: bcastRecord[m.sender][m.inRound] = TRUE 
-Invariant3 == \A p \in Proc: \A m \in bcastNetwork[p]: m \in bcastNetwork["History"] 
-Invariant6 == \A p,q \in Proc, r \in Rounds: DAG[p][r][q].source = q /\ DAG[p][r][q].round = r
-Invariant4 == \A p \in Proc : \A v \in buffer[p] : [ sender |-> v.source, inRound |-> v.round, vertex |-> v] \in bcastNetwork["History"]
+Invariant3 == \A p \in ProcessorSet: \A m \in bcastNetwork[p]: m \in bcastNetwork["History"] 
+Invariant6 == \A p,q \in ProcessorSet, r \in RoundSet: DAG[p][r][q].source = q /\ DAG[p][r][q].round = r
+Invariant4 == \A p \in ProcessorSet : \A v \in buffer[p] : [ sender |-> v.source, inRound |-> v.round, vertex |-> v] \in bcastNetwork["History"]
 Invariant5 == \A m,o \in bcastNetwork["History"]: m.sender = o.sender /\ m.inRound = o.inRound => m = o
 
 ----------------------------------------------------------------------------

--- a/DAGRider_Verification.tla
+++ b/DAGRider_Verification.tla
@@ -3,20 +3,20 @@ EXTENDS Integers, TLAPS, TLC, Sequences, DAGRider_Spec , FiniteSets
            
 LEMMA VerticesDef == Vertices' = Vertices 
       
-LEMMA tailType == ASSUME NEW S \in Seq(Blocks), S # <<>>
-      PROVE Tail(S) \in Seq(Blocks)
+LEMMA tailType == ASSUME NEW S \in Seq(BlockSet), S # <<>>
+      PROVE Tail(S) \in Seq(BlockSet)
       
-LEMMA DVinVertices == \A p \in Proc : dummy_vertex(p) \in Vertices  
+LEMMA DVinVertices == \A p \in ProcessorSet : dummy_vertex(p) \in Vertices  
 
-LEMMA nvinNV == \A p \in Proc, r \in Rounds : nil_vertex(p,r) \in NilVertices
+LEMMA nvinNV == \A p \in ProcessorSet, r \in RoundSet : nil_vertex(p,r) \in NilVertices
   
-LEMMA NVnotinVertices == \A p \in Proc, r \in Rounds : nil_vertex(p,r) \notin Vertices
+LEMMA NVnotinVertices == \A p \in ProcessorSet, r \in RoundSet : nil_vertex(p,r) \notin Vertices
 
-LEMMA type_cnv == ASSUME NEW p \in Proc, NEW r \in Rounds
+LEMMA type_cnv == ASSUME NEW p \in ProcessorSet, NEW r \in RoundSet
                   PROVE create_new_vertex(p, r) \in Vertices
                    
 LEMMA vertexType == ASSUME NEW v \in Vertices 
-                    PROVE v \in [round : Rounds, source : Proc, edges : SUBSET(Vertices)]
+                    PROVE v \in [round : RoundSet, source : ProcessorSet, edges : SUBSET(Vertices)]
 
 LEMMA divprop1 == ASSUME NEW n \in Nat, NEW x \in 0..4*n, x % 4 = 1
                  PROVE (x \div 4)+1 \in 1..n
@@ -24,18 +24,18 @@ LEMMA divprop1 == ASSUME NEW n \in Nat, NEW x \in 0..4*n, x % 4 = 1
 LEMMA divprop2 == ASSUME NEW n \in Nat, NEW x \in 0..4*n, x % 4 = 0, x>0
                   PROVE (x \div 4) \in 1..n
                   
-LEMMA 0isRound == 0 \in Rounds
+LEMMA 0isRound == 0 \in RoundSet
                                                      
 LEMMA Typecorrectness == Spec => []TypeOK 
  <1>1 Init => TypeOK
-      <2>1 0 \in Rounds
+      <2>1 0 \in RoundSet
            BY 0isRound
-      <2>2 ASSUME NEW r \in Rounds
+      <2>2 ASSUME NEW r \in RoundSet
            PROVE IF r = 0 THEN TRUE ELSE FALSE \in BOOLEAN
            OBVIOUS
       <2>3 ASSUME Init 
-           PROVE DAG \in [Proc -> [Rounds  -> [Proc -> Vertices \cup NilVertices]]]
-           <3>3 ASSUME NEW p \in Proc, NEW r \in Rounds, NEW q \in Proc
+           PROVE DAG \in [ProcessorSet -> [RoundSet  -> [ProcessorSet -> Vertices \cup NilVertices]]]
+           <3>3 ASSUME NEW p \in ProcessorSet, NEW r \in RoundSet, NEW q \in ProcessorSet
                 PROVE  DAG[p][r][q] \in Vertices \cup NilVertices
                 <4>1 DAG[p][r][q] =  IF r = 0 THEN dummy_vertex(q) ELSE nil_vertex(q,r)
                      BY <3>3,<2>3 DEF Init
@@ -48,13 +48,13 @@ LEMMA Typecorrectness == Spec => []TypeOK
       <2> QED BY <2>1,<2>2,<2>3 DEF Init, TypeOK
  <1>2 ASSUME [Next]_vars, TypeOK
       PROVE TypeOK' 
-      <2>1 ASSUME NEW p \in Proc, NEW r \in Rounds, NEW v \in Vertices, bcast(p,r,v)
-           PROVE /\ bcastNetwork' \in [Proc \cup {"History"} ->SUBSET(TaggedVertices)]
-                 /\ bcastRecord' \in [Proc -> [Rounds -> BOOLEAN]]
+      <2>1 ASSUME NEW p \in ProcessorSet, NEW r \in RoundSet, NEW v \in Vertices, bcast(p,r,v)
+           PROVE /\ bcastNetwork' \in [ProcessorSet \cup {"History"} ->SUBSET(TaggedVertices)]
+                 /\ bcastRecord' \in [ProcessorSet -> [RoundSet -> BOOLEAN]]
            <3>1 CASE bcastRecord[p][r] = FALSE 
-                <4>1 [bcastRecord EXCEPT ![p][r] = TRUE] \in [Proc -> [Rounds -> BOOLEAN]]
+                <4>1 [bcastRecord EXCEPT ![p][r] = TRUE] \in [ProcessorSet -> [RoundSet -> BOOLEAN]]
                      BY <2>1,<1>2 DEF TypeOK
-                <4>2 [q \in Proc \cup {"History"} |-> bcastNetwork[q] \cup {[sender |-> p, inRound |-> r, vertex |-> v]}] \in [Proc \cup {"History"} ->SUBSET(TaggedVertices)]
+                <4>2 [q \in ProcessorSet \cup {"History"} |-> bcastNetwork[q] \cup {[sender |-> p, inRound |-> r, vertex |-> v]}] \in [ProcessorSet \cup {"History"} ->SUBSET(TaggedVertices)]
                      <5>1 [sender |-> p, inRound |-> r, vertex |-> v] \in TaggedVertices
                           BY <2>1 DEF TaggedVertices
                      <5> QED BY <2>1,<1>2,<5>1 DEF TypeOK
@@ -62,37 +62,37 @@ LEMMA Typecorrectness == Spec => []TypeOK
            <3>2 CASE bcastRecord[p][r] = TRUE
                 BY <3>2,<1>2,<2>1 DEF TypeOK, bcast
            <3> QED BY <3>1,<3>2,<1>2,<2>1 DEF TypeOK, bcast
-      <2>2 ASSUME NEW p \in Proc, NEW b \in Blocks, propose(p,b)
+      <2>2 ASSUME NEW p \in ProcessorSet, NEW b \in BlockSet, propose(p,b)
            PROVE TypeOK'
-           <3>3 blocksToPropose[p] \in Seq(Blocks)
+           <3>3 blocksToPropose[p] \in Seq(BlockSet)
                 BY  <2>2,<1>2 DEF TypeOK
-           <3>1  Append(blocksToPropose[p], b) \in Seq(Blocks)
+           <3>1  Append(blocksToPropose[p], b) \in Seq(BlockSet)
                  BY <3>3 DEF TypeOK
-           <3>2 blocksToPropose' \in [Proc -> Seq(Blocks)]
+           <3>2 blocksToPropose' \in [ProcessorSet -> Seq(BlockSet)]
                 BY <3>1,<2>2,<1>2 DEF propose, TypeOK
            <3> QED BY <3>2, <2>2,<1>2, VerticesDef DEF propose, TypeOK, TaggedVertices
-      <2>3 ASSUME NEW p \in Proc, next_round(p)
+      <2>3 ASSUME NEW p \in ProcessorSet, next_round(p)
            PROVE TypeOK'
-            <3>1 [DAGround EXCEPT ![p] = DAGround[p]+1] \in [Proc -> Rounds]
+            <3>1 [DAGround EXCEPT ![p] = DAGround[p]+1] \in [ProcessorSet -> RoundSet]
                  BY <2>3,<1>2 DEF next_round, TypeOK
-            <3>2 [blocksToPropose EXCEPT ![p] = Tail(blocksToPropose[p])] \in [Proc -> Seq(Blocks)]
-                 <4>1 blocksToPropose[p] \in Seq(Blocks) /\ blocksToPropose[p] # <<>>
+            <3>2 [blocksToPropose EXCEPT ![p] = Tail(blocksToPropose[p])] \in [ProcessorSet -> Seq(BlockSet)]
+                 <4>1 blocksToPropose[p] \in Seq(BlockSet) /\ blocksToPropose[p] # <<>>
                       BY <2>3,<1>2,<2>3 DEF TypeOK, next_round  
-                 <4>2 Tail(blocksToPropose[p]) \in Seq(Blocks)
+                 <4>2 Tail(blocksToPropose[p]) \in Seq(BlockSet)
                       BY <4>1, tailType
                  <4> QED BY <4>2,<2>3,<1>2 DEF TypeOK    
             <3> QED BY <3>1,<3>2, <2>3,<1>2,<2>1, VerticesDef, type_cnv DEF next_round, TypeOK, TaggedVertices
-      <2>4 ASSUME NEW p \in Proc, NEW v \in Vertices, NEW r \in Rounds, NEW q \in Proc, p # q, recieve_vertex(p, q, r, v)
+      <2>4 ASSUME NEW p \in ProcessorSet, NEW v \in Vertices, NEW r \in RoundSet, NEW q \in ProcessorSet, p # q, recieve_vertex(p, q, r, v)
            PROVE TypeOK'
-           <3>1 buffer' \in [Proc -> SUBSET(Vertices)]
+           <3>1 buffer' \in [ProcessorSet -> SUBSET(Vertices)]
                 BY <2>4,<1>2 DEF TypeOK, recieve_vertex
-           <3>2 bcastNetwork' \in [Proc \cup {"History"} ->SUBSET(TaggedVertices)]
+           <3>2 bcastNetwork' \in [ProcessorSet \cup {"History"} ->SUBSET(TaggedVertices)]
                 BY <2>4,<1>2 DEF TypeOK, recieve_vertex
            <3> QED BY <3>1,<3>2, <2>4,<1>2,<2>1, VerticesDef DEF recieve_vertex, TypeOK, TaggedVertices
-      <2>5 ASSUME NEW p \in Proc, NEW v \in Vertices, add_vertex(p,v)
+      <2>5 ASSUME NEW p \in ProcessorSet, NEW v \in Vertices, add_vertex(p,v)
            PROVE TypeOK'
-           <3>1 DAG' \in [Proc -> [Rounds -> [Proc -> Vertices \cup NilVertices]]]
-                <4>1 v.round \in Rounds /\ v.source \in Proc \*/\ v.source \in Proc
+           <3>1 DAG' \in [ProcessorSet -> [RoundSet -> [ProcessorSet -> Vertices \cup NilVertices]]]
+                <4>1 v.round \in RoundSet /\ v.source \in ProcessorSet \*/\ v.source \in ProcessorSet
                      BY vertexType, <2>5 
                 <4>2 DAG' = [DAG EXCEPT ![p][v.round][v.source] = v]
                      BY <2>5, <1>2  DEF add_vertex, TypeOK
@@ -103,10 +103,10 @@ LEMMA Typecorrectness == Spec => []TypeOK
       <2> QED  BY <2>2,<2>3,<2>4,<2>5,<2>6,<1>2 DEF Next  
  <1> QED BY <1>1,<1>2,PTL DEF Spec
 
-\*\A p,q \in Proc, r \in Rounds : r # 0 /\ DAG[p][r][q] \in Vertices => DAG[p][r][q] \in buffer[p]
+\*\A p,q \in ProcessorSet, r \in RoundSet : r # 0 /\ DAG[p][r][q] \in Vertices => DAG[p][r][q] \in buffer[p]
 LEMMA Invariant1correctness == Spec => []Invariant1
  <1>1 Init => Invariant1
-      <2>1 ASSUME NEW p \in Proc, NEW q \in Proc, NEW r \in Rounds, r # 0, Init
+      <2>1 ASSUME NEW p \in ProcessorSet, NEW q \in ProcessorSet, NEW r \in RoundSet, r # 0, Init
            PROVE DAG[p][r][q] \notin Vertices
            <3>1 DAG[p][r][q] = nil_vertex(q,r)
                 BY <2>1 DEF Init
@@ -114,15 +114,15 @@ LEMMA Invariant1correctness == Spec => []Invariant1
       <2> QED BY <2>1 DEF Invariant1
  <1>2 ASSUME [Next]_vars,TypeOK, TypeOK', Invariant1
       PROVE Invariant1'
-      <2>1 ASSUME NEW p \in Proc, NEW b \in Blocks, propose(p,b)
+      <2>1 ASSUME NEW p \in ProcessorSet, NEW b \in BlockSet, propose(p,b)
            PROVE Invariant1'
            BY VerticesDef,<2>1,<1>2 DEF Invariant1, propose
-      <2>2 ASSUME NEW p \in Proc, next_round(p)
+      <2>2 ASSUME NEW p \in ProcessorSet, next_round(p)
            PROVE Invariant1'
            BY VerticesDef,<2>2,<1>2 DEF Invariant1, next_round
-      <2>3 ASSUME NEW p \in Proc, NEW r \in Rounds, NEW q \in Proc, NEW v \in Vertices, p# q, recieve_vertex(p,q,r,v)
+      <2>3 ASSUME NEW p \in ProcessorSet, NEW r \in RoundSet, NEW q \in ProcessorSet, NEW v \in Vertices, p# q, recieve_vertex(p,q,r,v)
            PROVE Invariant1'
-           <3>1 ASSUME NEW t \in Proc
+           <3>1 ASSUME NEW t \in ProcessorSet
                 PROVE  buffer[t] \in SUBSET(buffer'[t])
                 <4>1 CASE t = p
                      BY <4>1,<2>3,<1>2 DEF recieve_vertex,TypeOK
@@ -130,9 +130,9 @@ LEMMA Invariant1correctness == Spec => []Invariant1
                      BY <4>2,<2>3,<1>2 DEF recieve_vertex,TypeOK
                 <4> QED BY <4>1,<4>2
            <3> QED BY VerticesDef,<2>3, <1>2,<3>1 DEF Invariant1, recieve_vertex
-      <2>4 ASSUME NEW p \in Proc, NEW v \in Vertices, add_vertex(p,v)
+      <2>4 ASSUME NEW p \in ProcessorSet, NEW v \in Vertices, add_vertex(p,v)
            PROVE Invariant1'
-           <3>1 ASSUME NEW q \in Proc, NEW t \in Proc,NEW r \in Rounds, r # 0, DAG'[q][r][t] \in Vertices
+           <3>1 ASSUME NEW q \in ProcessorSet, NEW t \in ProcessorSet,NEW r \in RoundSet, r # 0, DAG'[q][r][t] \in Vertices
                 PROVE DAG'[q][r][t] \in buffer'[q]
                 <4>1 CASE q = p /\ r = v.round /\ t = v.source
                      <5>1 DAG'[q][r][t] = v
@@ -157,12 +157,12 @@ LEMMA Invariant2correctness == Spec => []Invariant2
       BY DEF Init, Invariant2
  <1>2 ASSUME [Next]_vars,TypeOK, TypeOK', Invariant2
       PROVE Invariant2'
-      <2>1 ASSUME NEW p \in Proc, NEW b \in Blocks, propose(p,b)
+      <2>1 ASSUME NEW p \in ProcessorSet, NEW b \in BlockSet, propose(p,b)
            PROVE Invariant2'
            BY VerticesDef,<2>1,<1>2 DEF Invariant2, propose
-      <2>2 ASSUME NEW p \in Proc, next_round(p)
+      <2>2 ASSUME NEW p \in ProcessorSet, next_round(p)
            PROVE Invariant2'
-           <3>1 ASSUME NEW r \in Rounds,NEW v \in Vertices, bcast(p,r,v)
+           <3>1 ASSUME NEW r \in RoundSet,NEW v \in Vertices, bcast(p,r,v)
                 PROVE Invariant2'
                 <4>1 CASE bcastRecord[p][r] = FALSE 
                      <5>1 bcastNetwork'["History"] = bcastNetwork["History"] \cup {[sender |-> p, inRound |-> r, vertex |-> v]}
@@ -171,14 +171,14 @@ LEMMA Invariant2correctness == Spec => []Invariant2
                           BY <3>1,<2>2,<1>2,<4>1 DEF TypeOK, bcast
                      <5>3 ASSUME NEW m \in bcastNetwork'["History"]
                           PROVE bcastRecord'[m.sender][m.inRound] = TRUE
-                          <6>1 m.sender \in Proc /\ m.inRound \in Rounds
-                               <7>1 bcastNetwork'["History"] \in SUBSET[sender : Proc, inRound : Rounds, vertex : Vertices']
+                          <6>1 m.sender \in ProcessorSet /\ m.inRound \in RoundSet
+                               <7>1 bcastNetwork'["History"] \in SUBSET[sender : ProcessorSet, inRound : RoundSet, vertex : Vertices']
                                     BY <1>2 DEF TypeOK, TaggedVertices
                                <7> QED BY <7>1,<5>3
                           <6>2 CASE m \in bcastNetwork["History"]
                                <7>1 bcastRecord[m.sender][m.inRound] = TRUE
                                     BY <6>2,<1>2 DEF Invariant2
-                               <7>2 ASSUME NEW a \in Proc, NEW b \in Rounds
+                               <7>2 ASSUME NEW a \in ProcessorSet, NEW b \in RoundSet
                                     PROVE bcastRecord'[a][b] = bcastRecord[a][b] \/ bcastRecord'[a][b] = TRUE
                                     <8>1 CASE a = p /\ b = r
                                          BY <8>1,<5>2, <1>2 DEF TypeOK
@@ -196,16 +196,16 @@ LEMMA Invariant2correctness == Spec => []Invariant2
                      <5> QED BY <5>1,<1>2 DEF Invariant2
                 <4> QED BY <4>1,<4>2,<3>1,<2>2,<1>2 DEF TypeOK 
            <3> QED BY VerticesDef,<2>2,<1>2, type_cnv,<3>1 DEF Invariant2, next_round, bcast
-      <2>3 ASSUME NEW p \in Proc, NEW r \in Rounds, NEW q \in Proc, NEW v \in Vertices, p# q, recieve_vertex(p,q,r,v)
+      <2>3 ASSUME NEW p \in ProcessorSet, NEW r \in RoundSet, NEW q \in ProcessorSet, NEW v \in Vertices, p# q, recieve_vertex(p,q,r,v)
            PROVE Invariant2'
            <3>1 bcastNetwork'["History"] =  bcastNetwork["History"]
                 <4>1 p # "History"
-                     BY <2>3, ProcAssumption DEF Proc
+                     BY <2>3, ProcSetAsm DEF ProcessorSet
                 <4> QED BY <4>1,<2>3,<1>2 DEF TypeOK, recieve_vertex
            <3>2 bcastRecord' = bcastRecord
                 BY <2>3 DEF recieve_vertex
            <3> QED BY <3>1,<3>2, VerticesDef,<2>3,<1>2 DEF Invariant2, recieve_vertex
-      <2>4 ASSUME NEW p \in Proc, NEW v \in Vertices, add_vertex(p,v)
+      <2>4 ASSUME NEW p \in ProcessorSet, NEW v \in Vertices, add_vertex(p,v)
            PROVE Invariant2'
            BY VerticesDef,<2>4,<1>2 DEF Invariant2, add_vertex
       <2>5 CASE UNCHANGED vars
@@ -218,22 +218,22 @@ LEMMA Invariant3correctness == Spec => []Invariant3
       BY DEF Init, Invariant3
  <1>2 ASSUME [Next]_vars,TypeOK, TypeOK', Invariant3
       PROVE Invariant3'
-      <2>1 ASSUME NEW p \in Proc, NEW b \in Blocks, propose(p,b)
+      <2>1 ASSUME NEW p \in ProcessorSet, NEW b \in BlockSet, propose(p,b)
            PROVE Invariant3'
            BY VerticesDef,<2>1,<1>2 DEF Invariant3, propose
-      <2>2 ASSUME NEW p \in Proc, next_round(p)
+      <2>2 ASSUME NEW p \in ProcessorSet, next_round(p)
            PROVE Invariant3'
            BY VerticesDef,<2>2,<1>2 DEF Invariant3, next_round, bcast
-      <2>3 ASSUME NEW p \in Proc, NEW r \in Rounds, NEW q \in Proc, NEW v \in Vertices, p# q, recieve_vertex(p,q,r,v)
+      <2>3 ASSUME NEW p \in ProcessorSet, NEW r \in RoundSet, NEW q \in ProcessorSet, NEW v \in Vertices, p# q, recieve_vertex(p,q,r,v)
            PROVE Invariant3'
            <3>1 bcastNetwork'["History"] =  bcastNetwork["History"]
                 <4>1 p # "History"
-                     BY <2>3, ProcAssumption DEF Proc
+                     BY <2>3, ProcSetAsm DEF ProcessorSet
                 <4> QED BY <4>1,<2>3,<1>2 DEF TypeOK, recieve_vertex
-           <3>2 \A z \in Proc : bcastNetwork'[z] \in SUBSET(bcastNetwork[z])
+           <3>2 \A z \in ProcessorSet : bcastNetwork'[z] \in SUBSET(bcastNetwork[z])
                 BY <2>3,<1>2 DEF TypeOK, recieve_vertex
            <3> QED BY <3>1,<3>2,<2>3,<1>2 DEF Invariant3, recieve_vertex
-      <2>4 ASSUME NEW p \in Proc, NEW v \in Vertices, add_vertex(p,v)
+      <2>4 ASSUME NEW p \in ProcessorSet, NEW v \in Vertices, add_vertex(p,v)
            PROVE Invariant3'
            BY VerticesDef,<2>4,<1>2 DEF Invariant3, add_vertex
       <2>5 CASE UNCHANGED vars
@@ -246,19 +246,19 @@ LEMMA Invariant4correctness == Spec => []Invariant4
       BY DEF Init, Invariant4
  <1>2 ASSUME [Next]_vars,TypeOK, TypeOK', Invariant4,Invariant3
       PROVE Invariant4'
-      <2>1 ASSUME NEW p \in Proc, NEW b \in Blocks, propose(p,b)
+      <2>1 ASSUME NEW p \in ProcessorSet, NEW b \in BlockSet, propose(p,b)
            PROVE Invariant4'
            BY VerticesDef,<2>1,<1>2 DEF Invariant4, propose
-      <2>2 ASSUME NEW p \in Proc, next_round(p)
+      <2>2 ASSUME NEW p \in ProcessorSet, next_round(p)
            PROVE Invariant4'
            BY VerticesDef,<2>2,<1>2 DEF Invariant4, next_round, bcast
-      <2>3 ASSUME NEW p \in Proc, NEW r \in Rounds, NEW q \in Proc, NEW v \in Vertices, p# q, recieve_vertex(p,q,r,v)
+      <2>3 ASSUME NEW p \in ProcessorSet, NEW r \in RoundSet, NEW q \in ProcessorSet, NEW v \in Vertices, p# q, recieve_vertex(p,q,r,v)
            PROVE Invariant4'
            <3>1 bcastNetwork'["History"] =  bcastNetwork["History"]
                 <4>1 p # "History"
-                     BY <2>3, ProcAssumption DEF Proc
+                     BY <2>3, ProcSetAsm DEF ProcessorSet
                 <4> QED BY <4>1,<2>3,<1>2 DEF TypeOK, recieve_vertex
-           <3>2 ASSUME NEW t \in Proc, NEW u \in buffer'[t]
+           <3>2 ASSUME NEW t \in ProcessorSet, NEW u \in buffer'[t]
                 PROVE [ sender |-> u.source, inRound |-> u.round, vertex |-> u] \in bcastNetwork'["History"]
                 <4>1 CASE p = t
                      <5>1 buffer'[p] = buffer[p] \cup {v}
@@ -278,7 +278,7 @@ LEMMA Invariant4correctness == Spec => []Invariant4
                      <5> QED BY <5>1,<3>1,<3>2,<1>2 DEF Invariant4
                 <4> QED BY <4>1,<4>2
            <3> QED BY <3>2,<2>3,<1>2 DEF Invariant4, recieve_vertex
-      <2>4 ASSUME NEW p \in Proc, NEW v \in Vertices, add_vertex(p,v)
+      <2>4 ASSUME NEW p \in ProcessorSet, NEW v \in Vertices, add_vertex(p,v)
            PROVE Invariant4'
            BY VerticesDef,<2>4,<1>2 DEF Invariant4, add_vertex
       <2>5 CASE UNCHANGED vars
@@ -291,12 +291,12 @@ LEMMA Invariant5correctness == Spec => []Invariant5
       BY DEF Init, Invariant5
  <1>2 ASSUME [Next]_vars,TypeOK, TypeOK', Invariant5, Invariant2
       PROVE Invariant5'
-      <2>1 ASSUME NEW p \in Proc, NEW b \in Blocks, propose(p,b)
+      <2>1 ASSUME NEW p \in ProcessorSet, NEW b \in BlockSet, propose(p,b)
            PROVE Invariant5'
            BY VerticesDef,<2>1,<1>2 DEF Invariant5, propose
-      <2>2 ASSUME NEW p \in Proc, next_round(p)
+      <2>2 ASSUME NEW p \in ProcessorSet, next_round(p)
            PROVE Invariant5'
-           <3>1 ASSUME NEW r \in Rounds,NEW v \in Vertices, bcast(p,r,v)
+           <3>1 ASSUME NEW r \in RoundSet,NEW v \in Vertices, bcast(p,r,v)
                 PROVE Invariant5'
                 <4>1 CASE bcastRecord[p][r] = FALSE 
                      <5>1 bcastNetwork'["History"] = bcastNetwork["History"] \cup {[sender |-> p, inRound |-> r, vertex |-> v]}
@@ -323,14 +323,14 @@ LEMMA Invariant5correctness == Spec => []Invariant5
                      <5> QED BY <5>1,<1>2 DEF Invariant5
                 <4> QED BY <4>1,<4>2,<3>1,<2>2,<1>2 DEF TypeOK 
            <3> QED BY VerticesDef,<2>2,<1>2, type_cnv,<3>1 DEF Invariant5, next_round, bcast
-      <2>3 ASSUME NEW p \in Proc, NEW r \in Rounds, NEW q \in Proc, NEW v \in Vertices, p# q, recieve_vertex(p,q,r,v)
+      <2>3 ASSUME NEW p \in ProcessorSet, NEW r \in RoundSet, NEW q \in ProcessorSet, NEW v \in Vertices, p# q, recieve_vertex(p,q,r,v)
            PROVE Invariant5'
            <3>1 bcastNetwork'["History"] =  bcastNetwork["History"]
                 <4>1 p # "History"
-                     BY <2>3, ProcAssumption DEF Proc
+                     BY <2>3, ProcSetAsm DEF ProcessorSet
                 <4> QED BY <4>1,<2>3,<1>2 DEF TypeOK, recieve_vertex
            <3> QED BY <3>1,VerticesDef,<2>3,<1>2 DEF Invariant5, recieve_vertex
-      <2>4 ASSUME NEW p \in Proc, NEW v \in Vertices, add_vertex(p,v)
+      <2>4 ASSUME NEW p \in ProcessorSet, NEW v \in Vertices, add_vertex(p,v)
            PROVE Invariant5'
            BY VerticesDef,<2>4,<1>2 DEF Invariant5, add_vertex
       <2>5 CASE UNCHANGED vars
@@ -338,11 +338,11 @@ LEMMA Invariant5correctness == Spec => []Invariant5
       <2> QED BY <1>2,<2>1,<2>2,<2>3,<2>4,<2>5 DEF Next 
  <1> QED BY <1>1,<1>2, Typecorrectness,Invariant2correctness, PTL DEF Spec
  
-\* \A p,q \in Proc, r \in Rounds: DAG[p][r][q].source = q /\ DAG[p][r][q].round = r
+\* \A p,q \in ProcessorSet, r \in RoundSet: DAG[p][r][q].source = q /\ DAG[p][r][q].round = r
  
 LEMMA Invariant6correctness == Spec => []Invariant6
  <1>1 TypeOK /\ Init => Invariant6
-      <2>1 ASSUME NEW q \in Proc, NEW t \in Proc, NEW r \in Rounds, Init, TypeOK
+      <2>1 ASSUME NEW q \in ProcessorSet, NEW t \in ProcessorSet, NEW r \in RoundSet, Init, TypeOK
            PROVE DAG[q][r][t].source = t /\ DAG[q][r][t].round = r
            <3>1 CASE r = 0
                 <4>1 DAG[q][r][t] = [round |-> r, source |-> t, block |-> "Empty", edges |-> {}]
@@ -360,18 +360,18 @@ LEMMA Invariant6correctness == Spec => []Invariant6
       <2> QED BY <2>1 DEF Invariant6          
  <1>2 ASSUME [Next]_vars,TypeOK, TypeOK', Invariant6
       PROVE Invariant6'
-      <2>1 ASSUME NEW p \in Proc, NEW b \in Blocks, propose(p,b)
+      <2>1 ASSUME NEW p \in ProcessorSet, NEW b \in BlockSet, propose(p,b)
            PROVE Invariant6'
            BY VerticesDef,<2>1,<1>2 DEF Invariant6, propose, Vertices
-      <2>2 ASSUME NEW p \in Proc, next_round(p)
+      <2>2 ASSUME NEW p \in ProcessorSet, next_round(p)
            PROVE Invariant6'
            BY VerticesDef,<2>2,<1>2 DEF Invariant6, next_round, Vertices
-      <2>3 ASSUME NEW p \in Proc, NEW r \in Rounds, NEW q \in Proc, NEW v \in Vertices, p# q, recieve_vertex(p,q,r,v)
+      <2>3 ASSUME NEW p \in ProcessorSet, NEW r \in RoundSet, NEW q \in ProcessorSet, NEW v \in Vertices, p# q, recieve_vertex(p,q,r,v)
            PROVE Invariant6'
            BY VerticesDef,<2>3,<1>2 DEF Invariant6, recieve_vertex, Vertices
-      <2>4 ASSUME NEW p \in Proc, NEW v \in Vertices, add_vertex(p,v)
+      <2>4 ASSUME NEW p \in ProcessorSet, NEW v \in Vertices, add_vertex(p,v)
            PROVE Invariant6'
-           <3>1 ASSUME NEW q \in Proc, NEW t \in Proc, NEW r \in Rounds
+           <3>1 ASSUME NEW q \in ProcessorSet, NEW t \in ProcessorSet, NEW r \in RoundSet
                 PROVE DAG'[q][r][t].source = t /\ DAG'[q][r][t].round = r
                 <4>1 CASE q = p /\ r = v.round /\ t = v.source
                      <5>1 DAG'[q][r][t] = v
@@ -394,16 +394,16 @@ LEMMA DAGConsistencycorrectness == Spec => []DAGConsistency
     <2> SUFFICES ASSUME DAGConsistency, [Next]_vars,Invariant1',Invariant4',Invariant6', Invariant5'
                   PROVE DAGConsistency'
                   OBVIOUS
-    <2>1 ASSUME NEW p \in Proc, NEW q \in Proc, NEW  r \in Rounds, NEW k \in Proc, r # 0, DAG'[p][r][k] \in Vertices, DAG'[q][r][k] \in Vertices
+    <2>1 ASSUME NEW p \in ProcessorSet, NEW q \in ProcessorSet, NEW  r \in RoundSet, NEW k \in ProcessorSet, r # 0, DAG'[p][r][k] \in Vertices, DAG'[q][r][k] \in Vertices
               PROVE DAG'[p][r][k] = DAG'[q][r][k]
         <3>1 CASE r = 0
              BY <3>1,<2>1
         <3>2 CASE r # 0
-             <4>1 \A a, b \in Proc, z \in Rounds : DAG'[a][z][b].source = b /\ DAG'[a][z][b].round = z
+             <4>1 \A a, b \in ProcessorSet, z \in RoundSet : DAG'[a][z][b].source = b /\ DAG'[a][z][b].round = z
                   BY DEF Invariant6
              <4>2 DAG'[p][r][k].source = k /\ DAG'[p][r][k].round = r /\ DAG'[q][r][k].source = k /\ DAG'[q][r][k].round = r
                   BY <2>1,<4>1
-             <4>3 \A p_1, q_1 \in Proc, r_1 \in Rounds : r_1 # 0 /\ DAG'[p_1][r_1][q_1] \in Vertices => DAG'[p_1][r_1][q_1] \in buffer'[p_1]
+             <4>3 \A p_1, q_1 \in ProcessorSet, r_1 \in RoundSet : r_1 # 0 /\ DAG'[p_1][r_1][q_1] \in Vertices => DAG'[p_1][r_1][q_1] \in buffer'[p_1]
                   BY VerticesDef DEF Invariant1 
              <4>4 DAG'[p][r][k] \in buffer'[p] /\  DAG'[q][r][k] \in buffer'[q]
                   BY <2>1,<4>3,<3>2
@@ -411,47 +411,47 @@ LEMMA DAGConsistencycorrectness == Spec => []DAGConsistency
                   BY <2>1,<4>4, <4>2 DEF Invariant4
              <4> QED BY <4>5 DEF Invariant5
         <3> QED BY <3>1,<3>2
-    <2>2 DAGConsistency' = \A a,b \in Proc, z \in Rounds, o \in Proc: z # 0 /\ DAG'[a][z][o] \in Vertices /\ DAG'[b][z][o] \in Vertices => DAG'[a][z][o] = DAG'[b][z][o]
+    <2>2 DAGConsistency' = \A a,b \in ProcessorSet, z \in RoundSet, o \in ProcessorSet: z # 0 /\ DAG'[a][z][o] \in Vertices /\ DAG'[b][z][o] \in Vertices => DAG'[a][z][o] = DAG'[b][z][o]
          BY VerticesDef DEF DAGConsistency    
     <2>3 QED BY <2>1,<2>2 
  <1> QED BY <1>1, <1>2, PTL, Invariant1correctness,Invariant4correctness,Invariant5correctness, Invariant6correctness DEF Spec      
             
 
-LEMMA unchangedDef == Waves = Chain!Waves /\ Proc = Chain!Proc /\ wAssumption = Chain!wAssumption /\ nAssumption = Chain!nAssumption 
-                      BY DEF  Waves, Chain!Waves, Proc, Chain!Proc, wAssumption, Chain!wAssumption,nAssumption, Chain!nAssumption 
+LEMMA unchangedDef == WaveSet = Chain!WaveSet /\ ProcessorSet = Chain!ProcessorSet /\ NumWaveAsm = Chain!NumWaveAsm /\ NumProcessorAsm = Chain!NumProcessorAsm 
+                      BY DEF  WaveSet, Chain!WaveSet, ProcessorSet, Chain!ProcessorSet, NumWaveAsm, Chain!NumWaveAsm,NumProcessorAsm, Chain!NumProcessorAsm 
 
 LEMMA Speccorrectness == Spec => Chain!Spec   
  <1>1 Init => Chain!Init
     BY DEF Init
  <1>2 ASSUME TypeOK, [Next]_vars 
       PROVE Chain!Next \/ UNCHANGED Chain!vars
-      <2>1 ASSUME NEW p \in Proc, NEW b \in Blocks, propose(p,b)
+      <2>1 ASSUME NEW p \in ProcessorSet, NEW b \in BlockSet, propose(p,b)
            PROVE Chain!Next \/ UNCHANGED Chain!vars
            BY VerticesDef,<2>1,<1>2 DEF  propose
-      <2>2 ASSUME NEW p \in Proc, next_round(p)
+      <2>2 ASSUME NEW p \in ProcessorSet, next_round(p)
            PROVE Chain!Next \/ UNCHANGED Chain!vars
-           <3>1 ASSUME NEW q \in Proc, NEW w \in Waves, wave_ready(p,w)
+           <3>1 ASSUME NEW q \in ProcessorSet, NEW w \in WaveSet, wave_ready(p,w)
                 PROVE Chain!Next \/ UNCHANGED Chain!vars
                 BY unchangedDef,<3>1,<1>2 DEF wave_ready, TypeOK, Chain!Next
            <3>2 CASE DAGround[p]>0 /\ (DAGround[p] % 4) = 0
-                <4>1 DAGround[p] \div 4 \in Waves
-                     BY divprop2,<3>2,<1>2,<2>1,wAssumption DEF TypeOK, Waves, Rounds
+                <4>1 DAGround[p] \div 4 \in WaveSet
+                     BY divprop2,<3>2,<1>2,<2>1,NumWaveAsm DEF TypeOK, WaveSet, RoundSet
                 <4> QED BY <4>1,<3>2,<3>1,<2>2,<1>2 DEF next_round
            <3>3 CASE ~(DAGround[p]>0 /\ (DAGround[p] % 4) = 0)
                 BY <3>3,<2>2 DEF next_round
            <3> QED BY <3>2,<3>3 
-      <2>3 ASSUME NEW p \in Proc, NEW r \in Rounds, NEW q \in Proc, NEW v \in Vertices, p# q, recieve_vertex(p,q,r,v)
+      <2>3 ASSUME NEW p \in ProcessorSet, NEW r \in RoundSet, NEW q \in ProcessorSet, NEW v \in Vertices, p# q, recieve_vertex(p,q,r,v)
            PROVE Chain!Next \/ UNCHANGED Chain!vars
            BY VerticesDef,<2>3,<1>2 DEF recieve_vertex
-      <2>4 ASSUME NEW p \in Proc, NEW v \in Vertices, add_vertex(p,v)
+      <2>4 ASSUME NEW p \in ProcessorSet, NEW v \in Vertices, add_vertex(p,v)
            PROVE Chain!Next \/ UNCHANGED Chain!vars
-           <3>1 CASE v.round % 4 = 1 /\ v.source = choose_leader((v.round \div 4)+1)
-                <4>1 (v.round \div 4)+1 \in Waves
-                     BY <3>1,vertexType,<2>4,wAssumption, divprop1 DEF Rounds, Waves
-                <4>2 waves_with_paths(p,v) \in SUBSET(Waves)
+           <3>1 CASE v.round % 4 = 1 /\ v.source = ChooseLeader((v.round \div 4)+1)
+                <4>1 (v.round \div 4)+1 \in WaveSet
+                     BY <3>1,vertexType,<2>4,NumWaveAsm, divprop1 DEF RoundSet, WaveSet
+                <4>2 waves_with_paths(p,v) \in SUBSET(WaveSet)
                      BY <2>4 DEF waves_with_paths
                 <4> QED BY <2>4,<3>1,<4>1,<4>2,unchangedDef DEF add_vertex, Chain!Next
-           <3>2 CASE v.round % 4 # 1 \/ v.source # choose_leader((v.round \div 4)+1)
+           <3>2 CASE v.round % 4 # 1 \/ v.source # ChooseLeader((v.round \div 4)+1)
                 BY <3>2,<2>4 DEF add_vertex
            <3> QED BY <3>1,<3>2, vertexType \*VerticesDef,<2>4,<1>2 DEF add_vertex
       <2>5 CASE UNCHANGED vars
@@ -460,12 +460,12 @@ LEMMA Speccorrectness == Spec => Chain!Spec
  <1> QED BY <1>1,<1>2,PTL, Typecorrectness DEF Spec, Chain!Spec   
 
 LEMMA SystemTypecorrectness == Spec => []TypeOK_System
-  BY Typecorrectness, PTL, Chain!Typecorrectness, Speccorrectness,wAssumption, nAssumption DEF TypeOK_System
+  BY Typecorrectness, PTL, Chain!Typecorrectness, Speccorrectness,NumWaveAsm, NumProcessorAsm DEF TypeOK_System
 
 LEMMA ChainConsistancycorrectness == Spec=> []ChainConsistancy  
-  BY Chain!ChainConsistancycorrectness,Speccorrectness,wAssumption, nAssumption, unchangedDef DEF Chain!ChainConsistancy, ChainConsistancy
+  BY Chain!ChainConsistancycorrectness,Speccorrectness,NumWaveAsm, NumProcessorAsm, unchangedDef DEF Chain!ChainConsistancy, ChainConsistancy
 LEMMA ChainMonotonicitycorrectness == Spec => []ChainMonotonicity
-  BY Chain!ChainMonotonicitycorrectness,Speccorrectness,wAssumption, nAssumption, unchangedDef DEF Chain!ChainMonotonicity, ChainMonotonicity
+  BY Chain!ChainMonotonicitycorrectness,Speccorrectness,NumWaveAsm, NumProcessorAsm, unchangedDef DEF Chain!ChainMonotonicity, ChainMonotonicity
 
 =============================================================================
 \* Modification History

--- a/LeaderConsensus_Spec.tla
+++ b/LeaderConsensus_Spec.tla
@@ -1,69 +1,69 @@
 ------------------------ MODULE LeaderConsensus_Spec ------------------------
 EXTENDS Integers, TLAPS, TLC, Sequences, FiniteSets, SequenceOps
 
-CONSTANTS n_DAG,
-          w_DAG
+CONSTANTS NumProcessors,
+          NumWaves
 
-Proc == 1..n_DAG
-Waves == 1..w_DAG
+ProcessorSet == 1..NumProcessors
+WaveSet == 1..NumWaves
           
-ASSUME nAssumption == n_DAG \in Nat\{0}
-ASSUME wAssumption == w_DAG \in Nat\{0}
+ASSUME NumProcessorAsm == NumProcessors \in Nat\{0}
+ASSUME NumWaveAsm == NumWaves \in Nat\{0}
 
 VARIABLES record, decidedRefWave, leaderSeq, commitWithRef
 
-TypeOK == /\ record \in [Proc -> [Waves -> [exists : BOOLEAN, edges : SUBSET(Waves)]]]
-          /\ decidedRefWave \in [Proc -> Waves \cup {0}]
-          /\ leaderSeq \in [Proc -> [current : Seq(Waves), last : Seq(Waves)]]
-          /\ commitWithRef \in [Proc -> [Waves -> Seq(Waves)]]
+TypeOK == /\ record \in [ProcessorSet -> [WaveSet -> [exists : BOOLEAN, edges : SUBSET(WaveSet)]]]
+          /\ decidedRefWave \in [ProcessorSet -> WaveSet \cup {0}]
+          /\ leaderSeq \in [ProcessorSet -> [current : Seq(WaveSet), last : Seq(WaveSet)]]
+          /\ commitWithRef \in [ProcessorSet -> [WaveSet -> Seq(WaveSet)]]
 
-Init == /\ record = [p \in Proc |-> [w \in Waves |->[exists |-> FALSE, edges |-> {}]]]
-        /\ decidedRefWave = [p \in Proc |-> 0]
-        /\ leaderSeq = [p \in Proc |-> [current |-> <<>>, last |-> <<>>]]
-        /\ commitWithRef = [p \in Proc |-> [w \in Waves |-> <<>>]]
+Init == /\ record = [p \in ProcessorSet |-> [w \in WaveSet |->[exists |-> FALSE, edges |-> {}]]]
+        /\ decidedRefWave = [p \in ProcessorSet |-> 0]
+        /\ leaderSeq = [p \in ProcessorSet |-> [current |-> <<>>, last |-> <<>>]]
+        /\ commitWithRef = [p \in ProcessorSet |-> [w \in WaveSet |-> <<>>]]
         
 max(E) == IF E # {} /\ Cardinality(E) \in Nat THEN CHOOSE x \in E : \A y \in E : y <= x ELSE "Error"   
   
 update_record(p, w, E) == /\ record[p][w].exists = FALSE
                           /\ \A x \in E : record[p][x].exists = TRUE
                           /\ \A x \in E : x < w
-                          /\ \A q \in Proc : record[q][w].exists = TRUE => record[q][w].edges = E
-                          /\ \A q \in Proc : decidedRefWave[q] # 0 /\ decidedRefWave[q] < w => decidedRefWave[q] \in E
+                          /\ \A q \in ProcessorSet : record[q][w].exists = TRUE => record[q][w].edges = E
+                          /\ \A q \in ProcessorSet : decidedRefWave[q] # 0 /\ decidedRefWave[q] < w => decidedRefWave[q] \in E
                           /\ record' = [record EXCEPT ![p][w] = [exists |-> TRUE, edges |-> E]]
                           /\ commitWithRef' = [commitWithRef EXCEPT ![p][w] = IF E = {} THEN <<w>> ELSE Append(commitWithRef[p][max(E)], w)]
                           /\ UNCHANGED <<decidedRefWave, leaderSeq>>
 
 update_decidedRefWave(p, w) == /\ record[p][w].exists = TRUE
                                /\ w >= decidedRefWave[p]
-                               /\ \A x \in Waves : x > w => record[p][x].exists = FALSE 
-                               /\ \A q \in Proc, x \in Waves : x > w /\ record[q][x].exists = TRUE => w \in record[q][x].edges
+                               /\ \A x \in WaveSet : x > w => record[p][x].exists = FALSE 
+                               /\ \A q \in ProcessorSet, x \in WaveSet : x > w /\ record[q][x].exists = TRUE => w \in record[q][x].edges
                                /\ decidedRefWave' = [decidedRefWave EXCEPT ![p] = w]
                                /\ leaderSeq' = [leaderSeq EXCEPT ![p] = [current |-> commitWithRef[p][w] ,last |-> leaderSeq[p].current]]
                                /\ UNCHANGED <<record, commitWithRef>>
                                
-Next == \E p \in Proc, w \in Waves, E \in SUBSET(Waves) : update_record(p, w, E) \/ update_decidedRefWave(p, w)
+Next == \E p \in ProcessorSet, w \in WaveSet, E \in SUBSET(WaveSet) : update_record(p, w, E) \/ update_decidedRefWave(p, w)
 
 vars == <<record, decidedRefWave, leaderSeq, commitWithRef>>
 
 Spec == Init /\ [][Next]_vars
 
 
-ChainMonotonicity == \A p \in Proc : IsPrefix(leaderSeq[p].last, leaderSeq[p].current)
+ChainMonotonicity == \A p \in ProcessorSet : IsPrefix(leaderSeq[p].last, leaderSeq[p].current)
 
-ChainConsistancy == \A p,q \in Proc : decidedRefWave[p] <= decidedRefWave[q] => IsPrefix(leaderSeq[p].current, leaderSeq[q].current)
+ChainConsistancy == \A p,q \in ProcessorSet : decidedRefWave[p] <= decidedRefWave[q] => IsPrefix(leaderSeq[p].current, leaderSeq[q].current)
 
 Contains(w, S) == \E i \in 1..Len(S) : S[i]=w
 
-Invariant1 == \A p \in Proc : decidedRefWave[p] # 0 => record[p][decidedRefWave[p]].exists = TRUE
-Invariant2 == \A p \in Proc : leaderSeq[p].current = IF decidedRefWave[p] = 0 THEN <<>> ELSE commitWithRef[p][decidedRefWave[p]]
-Invariant3 == \A p \in Proc, w \in Waves: \A x \in record[p][w].edges : record[p][x].exists = TRUE
-Invariant4 == \A p \in Proc, w,x \in Waves : Contains(w, commitWithRef[p][x]) => record[p][w].exists = TRUE
-Invariant5 == \A p \in Proc, w,x \in Waves : Contains(w, commitWithRef[p][x]) => IsPrefix(commitWithRef[p][w], commitWithRef[p][x])
-Invariant6 == \A p \in Proc, w \in Waves: record[p][w].exists = TRUE => commitWithRef[p][w] = IF record[p][w].edges = {} THEN <<w>> ELSE Append(commitWithRef[p][max(record[p][w].edges)], w) 
-Invariant7 == \A p, q \in Proc, w \in Waves : record[p][w].exists = record[q][w].exists => commitWithRef[p][w] = commitWithRef[q][w]
-Invariant8 == \A p \in Proc, w \in Waves : (\A y \in Waves : y > w /\ record[p][y].exists => w \in record[p][y].edges) => (\A y \in Waves : y >= w /\ record[p][y].exists => Contains(w, commitWithRef[p][y])) 
-Invariant9 == \A p,q \in Proc, w \in Waves : decidedRefWave[p] # 0 /\ w >= decidedRefWave[p] /\ record[q][w].exists = TRUE => Contains(decidedRefWave[p], commitWithRef[q][w])
-Invariant10 == \A p,q \in Proc, w \in Waves : record[p][w].exists = TRUE /\ w >= decidedRefWave[q] /\ decidedRefWave[q] # 0 => IsPrefix(commitWithRef[q][decidedRefWave[q]], commitWithRef[p][w]) 
+Invariant1 == \A p \in ProcessorSet : decidedRefWave[p] # 0 => record[p][decidedRefWave[p]].exists = TRUE
+Invariant2 == \A p \in ProcessorSet : leaderSeq[p].current = IF decidedRefWave[p] = 0 THEN <<>> ELSE commitWithRef[p][decidedRefWave[p]]
+Invariant3 == \A p \in ProcessorSet, w \in WaveSet: \A x \in record[p][w].edges : record[p][x].exists = TRUE
+Invariant4 == \A p \in ProcessorSet, w,x \in WaveSet : Contains(w, commitWithRef[p][x]) => record[p][w].exists = TRUE
+Invariant5 == \A p \in ProcessorSet, w,x \in WaveSet : Contains(w, commitWithRef[p][x]) => IsPrefix(commitWithRef[p][w], commitWithRef[p][x])
+Invariant6 == \A p \in ProcessorSet, w \in WaveSet: record[p][w].exists = TRUE => commitWithRef[p][w] = IF record[p][w].edges = {} THEN <<w>> ELSE Append(commitWithRef[p][max(record[p][w].edges)], w) 
+Invariant7 == \A p, q \in ProcessorSet, w \in WaveSet : record[p][w].exists = record[q][w].exists => commitWithRef[p][w] = commitWithRef[q][w]
+Invariant8 == \A p \in ProcessorSet, w \in WaveSet : (\A y \in WaveSet : y > w /\ record[p][y].exists => w \in record[p][y].edges) => (\A y \in WaveSet : y >= w /\ record[p][y].exists => Contains(w, commitWithRef[p][y])) 
+Invariant9 == \A p,q \in ProcessorSet, w \in WaveSet : decidedRefWave[p] # 0 /\ w >= decidedRefWave[p] /\ record[q][w].exists = TRUE => Contains(decidedRefWave[p], commitWithRef[q][w])
+Invariant10 == \A p,q \in ProcessorSet, w \in WaveSet : record[p][w].exists = TRUE /\ w >= decidedRefWave[q] /\ decidedRefWave[q] # 0 => IsPrefix(commitWithRef[q][decidedRefWave[q]], commitWithRef[p][w]) 
 
 =============================================================================
 \* Modification History

--- a/LeaderConsensus_Verification.tla
+++ b/LeaderConsensus_Verification.tla
@@ -1,31 +1,31 @@
 -------------------- MODULE LeaderConsensus_Verification --------------------
 EXTENDS Integers, TLAPS, TLC, Sequences, LeaderConsensus_Spec, FiniteSets, SequenceOpTheorems
 
-LEMMA maxIn == \A E \in SUBSET(Waves) : E # {} =>  max(E) \in E 
+LEMMA maxIn == \A E \in SUBSET(WaveSet) : E # {} =>  max(E) \in E 
       
-LEMMA maxProperty == \A E \in SUBSET(Waves) : \A x \in E: E # {} => x<=max(E)
+LEMMA maxProperty == \A E \in SUBSET(WaveSet) : \A x \in E: E # {} => x<=max(E)
 
-LEMMA SelfIsPrefix == \A S \in Seq(Waves) : IsPrefix(S, S) = TRUE
-      <1>1 \A S \in Seq(Waves) : S \o <<>> = S /\ <<>> \in Seq(Waves)
+LEMMA SelfIsPrefix == \A S \in Seq(WaveSet) : IsPrefix(S, S) = TRUE
+      <1>1 \A S \in Seq(WaveSet) : S \o <<>> = S /\ <<>> \in Seq(WaveSet)
            OBVIOUS
       <1> QED BY IsPrefixConcat, <1>1
       
-LEMMA transitiveIsPrefix == ASSUME NEW S \in Seq(Waves), NEW L \in Seq(Waves), NEW M \in Seq(Waves), IsPrefix(S,L), IsPrefix(L,M)
+LEMMA transitiveIsPrefix == ASSUME NEW S \in Seq(WaveSet), NEW L \in Seq(WaveSet), NEW M \in Seq(WaveSet), IsPrefix(S,L), IsPrefix(L,M)
                             PROVE IsPrefix(S,M)
-      <1>1 \E u,w \in Seq(Waves) : L = S \o u /\ M = L \o w
+      <1>1 \E u,w \in Seq(WaveSet) : L = S \o u /\ M = L \o w
            BY IsPrefixProperties
-      <1>2 \A n,m, u \in Seq(Waves) : (n \o m) \o u = n \o (m \o u)
+      <1>2 \A n,m, u \in Seq(WaveSet) : (n \o m) \o u = n \o (m \o u)
            OBVIOUS
-      <1>3  \E u,w \in Seq(Waves) : M = S \o (u \o w)
+      <1>3  \E u,w \in Seq(WaveSet) : M = S \o (u \o w)
            BY <1>1
-      <1>4 \A u,w \in Seq(Waves) : u \o w \in Seq(Waves) 
+      <1>4 \A u,w \in Seq(WaveSet) : u \o w \in Seq(WaveSet) 
            OBVIOUS
-      <1>5 \A u,w \in Seq(Waves) : M = S \o (u \o w) /\ u \o w \in Seq(Waves) => IsPrefix(S,M)
+      <1>5 \A u,w \in Seq(WaveSet) : M = S \o (u \o w) /\ u \o w \in Seq(WaveSet) => IsPrefix(S,M)
            BY IsPrefixConcat
       <1> QED BY <1>5,<1>4,<1>3
 
-LEMMA appendIsPrefix == \A S \in Seq(Waves), w \in Waves : IsPrefix(S, Append(S,w))
-      <1>1 \A S \in Seq(Waves), w \in Waves : <<w>> \in Seq(Waves) /\ Append(S,w) = S \o <<w>>
+LEMMA appendIsPrefix == \A S \in Seq(WaveSet), w \in WaveSet : IsPrefix(S, Append(S,w))
+      <1>1 \A S \in Seq(WaveSet), w \in WaveSet : <<w>> \in Seq(WaveSet) /\ Append(S,w) = S \o <<w>>
            OBVIOUS
       <1> QED BY <1>1, IsPrefixConcat
      
@@ -35,29 +35,29 @@ LEMMA Typecorrectness == Spec => []TypeOK
       BY DEF Init, TypeOK
  <1>2 ASSUME TypeOK, Next
       PROVE TypeOK'
-      <2>1 ASSUME NEW p \in Proc, NEW w \in Waves, NEW E \in SUBSET(Waves), update_record(p, w, E)
+      <2>1 ASSUME NEW p \in ProcessorSet, NEW w \in WaveSet, NEW E \in SUBSET(WaveSet), update_record(p, w, E)
            PROVE TypeOK'
-           <3>1 record' \in [Proc -> [Waves -> [exists : BOOLEAN, edges : SUBSET(Waves)]]]
-                BY  <2>1, <1>2 DEF Proc, Waves, TypeOK, update_record
-           <3>2 commitWithRef' \in [Proc -> [Waves -> Seq(Waves)]]
-                <4>1 <<w>> \in Seq(Waves)
+           <3>1 record' \in [ProcessorSet -> [WaveSet -> [exists : BOOLEAN, edges : SUBSET(WaveSet)]]]
+                BY  <2>1, <1>2 DEF ProcessorSet, WaveSet, TypeOK, update_record
+           <3>2 commitWithRef' \in [ProcessorSet -> [WaveSet -> Seq(WaveSet)]]
+                <4>1 <<w>> \in Seq(WaveSet)
                      BY <2>1 
-                <4>2 E # {} =>max(E) \in Waves
+                <4>2 E # {} =>max(E) \in WaveSet
                      BY maxIn,<2>1
-                <4>3 E # {} => Append(commitWithRef[p][max(E)], w) \in Seq(Waves)
-                     <5>1 E # {} => commitWithRef[p][max(E)] \in Seq(Waves)
+                <4>3 E # {} => Append(commitWithRef[p][max(E)], w) \in Seq(WaveSet)
+                     <5>1 E # {} => commitWithRef[p][max(E)] \in Seq(WaveSet)
                           BY <2>1, <4>2,<1>2 DEF TypeOK
                      <5> QED BY <5>1, <2>1 
                 <4> QED BY  <4>1,<4>3, <2>1, <1>2 DEF TypeOK, update_record
            <3> QED BY <3>1,<3>2, <2>1,<1>2 DEF TypeOK, update_record
-      <2>2 ASSUME NEW p \in Proc, NEW w \in Waves, update_decidedRefWave(p, w)
+      <2>2 ASSUME NEW p \in ProcessorSet, NEW w \in WaveSet, update_decidedRefWave(p, w)
            PROVE TypeOK'
-           <3>1 decidedRefWave' \in [Proc -> Waves \cup {0}]
-                BY  <2>2, <1>2 DEF Proc, Waves, TypeOK, update_decidedRefWave
-           <3>2 leaderSeq' \in [Proc -> [current : Seq(Waves), last : Seq(Waves)]]
-                <4>1 commitWithRef[p][w] \in Seq(Waves) /\ leaderSeq[p].current \in Seq(Waves)
+           <3>1 decidedRefWave' \in [ProcessorSet -> WaveSet \cup {0}]
+                BY  <2>2, <1>2 DEF ProcessorSet, WaveSet, TypeOK, update_decidedRefWave
+           <3>2 leaderSeq' \in [ProcessorSet -> [current : Seq(WaveSet), last : Seq(WaveSet)]]
+                <4>1 commitWithRef[p][w] \in Seq(WaveSet) /\ leaderSeq[p].current \in Seq(WaveSet)
                      BY <2>2, <1>2 DEF TypeOK
-                <4> QED BY  <4>1, <2>2, <1>2 DEF Proc, Waves, TypeOK, update_decidedRefWave
+                <4> QED BY  <4>1, <2>2, <1>2 DEF ProcessorSet, WaveSet, TypeOK, update_decidedRefWave
            <3> QED BY <3>1,<3>2, <2>2,<1>2 DEF TypeOK, update_decidedRefWave
       <2> QED BY <2>1,<2>2, <1>2 DEF Next
  <1>3 TypeOK /\ UNCHANGED vars => TypeOK'
@@ -70,11 +70,11 @@ LEMMA Invariant1correctness == Spec => []Invariant1
  <1>2 TypeOK /\ TypeOK' /\ Invariant1 /\ [Next]_vars => Invariant1'
       <2>1 ASSUME TypeOK, TypeOK', Next, Invariant1
            PROVE Invariant1'
-           <3>1 ASSUME NEW p \in Proc, NEW w \in Waves, NEW E \in SUBSET(Waves), update_record(p, w, E)
+           <3>1 ASSUME NEW p \in ProcessorSet, NEW w \in WaveSet, NEW E \in SUBSET(WaveSet), update_record(p, w, E)
                 PROVE Invariant1'
-                <4>1 ASSUME NEW q \in Proc, decidedRefWave'[q] # 0
+                <4>1 ASSUME NEW q \in ProcessorSet, decidedRefWave'[q] # 0
                      PROVE record'[q][decidedRefWave'[q]].exists = TRUE
-                     <5>1 decidedRefWave'[q] \in Waves
+                     <5>1 decidedRefWave'[q] \in WaveSet
                           BY <2>1, <4>1 DEF TypeOK
                      <5>2 CASE decidedRefWave'[q] = w /\ p = q 
                           BY <5>2,<3>1,<2>1 DEF TypeOK, update_record
@@ -86,11 +86,11 @@ LEMMA Invariant1correctness == Spec => []Invariant1
                           <6> QED BY <6>1,<6>2, <2>1 DEF Invariant1
                      <5> QED BY <5>3,<5>2
                 <4> QED BY <4>1 DEF Invariant1
-           <3>2 ASSUME NEW p \in Proc, NEW w \in Waves, update_decidedRefWave(p, w)
+           <3>2 ASSUME NEW p \in ProcessorSet, NEW w \in WaveSet, update_decidedRefWave(p, w)
                 PROVE Invariant1'
-                <4>1 ASSUME NEW q \in Proc, decidedRefWave'[q] # 0
+                <4>1 ASSUME NEW q \in ProcessorSet, decidedRefWave'[q] # 0
                      PROVE record'[q][decidedRefWave'[q]].exists = TRUE
-                     <5>1 decidedRefWave'[q] \in Waves
+                     <5>1 decidedRefWave'[q] \in WaveSet
                           BY <2>1, <4>1 DEF TypeOK
                      <5>2 CASE  p = q 
                           BY <5>2,<3>2,<2>1 DEF TypeOK, update_decidedRefWave
@@ -116,9 +116,9 @@ LEMMA Invariant2correctness == Spec => []Invariant2
  <1>2 TypeOK /\ TypeOK' /\ Invariant1 /\ Invariant1' /\ Invariant2 /\ [Next]_vars => Invariant2'
       <2>1 ASSUME TypeOK, TypeOK', Next, Invariant2, Invariant1, Invariant1'
            PROVE Invariant2'
-           <3>1 ASSUME NEW p \in Proc, NEW w \in Waves, NEW E \in SUBSET(Waves), update_record(p, w, E)
+           <3>1 ASSUME NEW p \in ProcessorSet, NEW w \in WaveSet, NEW E \in SUBSET(WaveSet), update_record(p, w, E)
                 PROVE Invariant2'
-                <4>1 ASSUME NEW q \in Proc 
+                <4>1 ASSUME NEW q \in ProcessorSet 
                      PROVE leaderSeq'[q].current = IF decidedRefWave'[q] = 0 THEN <<>> ELSE commitWithRef'[q][decidedRefWave'[q]]
                      <5>1 leaderSeq'[q].current = leaderSeq[q].current
                           BY <4>1, <3>1,<2>1 DEF TypeOK, update_record
@@ -136,16 +136,16 @@ LEMMA Invariant2correctness == Spec => []Invariant2
                           <6> QED BY <6>1,<6>2
                      <5> QED BY <5>1,<5>2,<5>3, <2>1 DEF Invariant2
                 <4> QED BY <4>1 DEF Invariant2  
-           <3>2 ASSUME NEW p \in Proc, NEW w \in Waves, update_decidedRefWave(p, w)
+           <3>2 ASSUME NEW p \in ProcessorSet, NEW w \in WaveSet, update_decidedRefWave(p, w)
                 PROVE Invariant2'
-                <4>1 ASSUME NEW q \in Proc 
+                <4>1 ASSUME NEW q \in ProcessorSet 
                      PROVE leaderSeq'[q].current = IF decidedRefWave'[q] = 0 THEN <<>> ELSE commitWithRef'[q][decidedRefWave'[q]]
                      <5>1 CASE p = q
                           <6>1 decidedRefWave'[q] = w
                                BY <5>1, <3>2,<2>1 DEF TypeOK, update_decidedRefWave
                           <6>2 leaderSeq'[q].current = commitWithRef'[q][decidedRefWave'[q]]
                                BY <5>1, <3>2,<2>1, <6>1 DEF TypeOK, update_decidedRefWave
-                          <6> QED BY <6>1, <6>2, <3>1 DEF Waves
+                          <6> QED BY <6>1, <6>2, <3>1 DEF WaveSet
                      <5>2 CASE p # q
                           <6>1 leaderSeq'[q].current =leaderSeq[q].current
                                BY <4>1, <5>2, <3>2,<2>1 DEF TypeOK, update_decidedRefWave
@@ -170,11 +170,11 @@ LEMMA Invariant3correctness == Spec => []Invariant3
  <1>2 TypeOK /\ TypeOK' /\ Invariant3 /\ [Next]_vars => Invariant3'
       <2>1 ASSUME TypeOK, TypeOK', Next, Invariant3
            PROVE Invariant3'
-           <3>1 ASSUME NEW p \in Proc, NEW w \in Waves, NEW E \in SUBSET(Waves), update_record(p, w, E)
+           <3>1 ASSUME NEW p \in ProcessorSet, NEW w \in WaveSet, NEW E \in SUBSET(WaveSet), update_record(p, w, E)
                 PROVE Invariant3'
-                <4>1 ASSUME NEW q \in Proc, NEW x \in Waves, NEW y \in record'[q][x].edges
+                <4>1 ASSUME NEW q \in ProcessorSet, NEW x \in WaveSet, NEW y \in record'[q][x].edges
                      PROVE record'[q][y].exists = TRUE
-                     <5>1 y \in Waves
+                     <5>1 y \in WaveSet
                           BY <4>1, <2>1 DEF TypeOK
                      <5>2 CASE q = p /\ x = w
                           BY <5>2,<3>1,<2>1,<4>1 DEF TypeOK, update_record
@@ -190,9 +190,9 @@ LEMMA Invariant3correctness == Spec => []Invariant3
                           <6> QED BY <6>1,<6>2,<4>1,<2>1 DEF Invariant3, TypeOK
                      <5> QED  BY <5>2,<5>3 
                 <4> QED BY <4>1 DEF Invariant3
-           <3>2 ASSUME NEW p \in Proc, NEW w \in Waves, update_decidedRefWave(p, w)
+           <3>2 ASSUME NEW p \in ProcessorSet, NEW w \in WaveSet, update_decidedRefWave(p, w)
                 PROVE Invariant3'
-                <4>1 ASSUME NEW q \in Proc, NEW x \in Waves, NEW y \in record'[q][x].edges
+                <4>1 ASSUME NEW q \in ProcessorSet, NEW x \in WaveSet, NEW y \in record'[q][x].edges
                      PROVE record'[q][y].exists = TRUE 
                      <5>1 record'[q][x].edges = record[q][x].edges 
                           BY <4>1,<3>2,<2>1 DEF TypeOK, update_decidedRefWave
@@ -214,9 +214,9 @@ LEMMA Invariant4correctness == Spec => []Invariant4
  <1>2 TypeOK /\ TypeOK' /\ Invariant4 /\ [Next]_vars => Invariant4'
       <2>1 ASSUME TypeOK, TypeOK', Next, Invariant4
            PROVE Invariant4'
-           <3>1 ASSUME NEW p \in Proc, NEW w \in Waves, NEW E \in SUBSET(Waves), update_record(p, w, E)
+           <3>1 ASSUME NEW p \in ProcessorSet, NEW w \in WaveSet, NEW E \in SUBSET(WaveSet), update_record(p, w, E)
                 PROVE Invariant4'
-                <4>1 ASSUME NEW q \in Proc, NEW x \in Waves, NEW y \in Waves, Contains(x, commitWithRef'[q][y])
+                <4>1 ASSUME NEW q \in ProcessorSet, NEW x \in WaveSet, NEW y \in WaveSet, Contains(x, commitWithRef'[q][y])
                      PROVE record'[q][x].exists = TRUE
                      <5>1 CASE p = q
                           <6>1 CASE x = w
@@ -238,9 +238,9 @@ LEMMA Invariant4correctness == Spec => []Invariant4
                           BY <5>2,<4>1,<3>1,<2>1 DEF TypeOK, Invariant4, update_record
                      <5> QED BY <5>1,<5>2 
                 <4> QED BY <4>1 DEF Invariant4
-           <3>2 ASSUME NEW p \in Proc, NEW w \in Waves, update_decidedRefWave(p, w)
+           <3>2 ASSUME NEW p \in ProcessorSet, NEW w \in WaveSet, update_decidedRefWave(p, w)
                 PROVE Invariant4'
-                <4>1 ASSUME NEW q \in Proc, NEW x \in Waves, NEW y \in Waves, Contains(x, commitWithRef'[q][y])
+                <4>1 ASSUME NEW q \in ProcessorSet, NEW x \in WaveSet, NEW y \in WaveSet, Contains(x, commitWithRef'[q][y])
                      PROVE record'[q][x].exists = TRUE
                      BY <4>1,<3>2,<2>1 DEF TypeOK, Invariant4, update_decidedRefWave
                 <4> QED BY <4>1 DEF Invariant4
@@ -258,9 +258,9 @@ LEMMA Invariant5correctness == Spec => []Invariant5
  <1>2 TypeOK /\ TypeOK' /\ Invariant5 /\ [Next]_vars /\ Invariant4 /\ Invariant4' => Invariant5'
       <2>1 ASSUME TypeOK, TypeOK', Next, Invariant5, Invariant4, Invariant4'
            PROVE Invariant5'
-           <3>1 ASSUME NEW p \in Proc, NEW w \in Waves, NEW E \in SUBSET(Waves), update_record(p, w, E)
+           <3>1 ASSUME NEW p \in ProcessorSet, NEW w \in WaveSet, NEW E \in SUBSET(WaveSet), update_record(p, w, E)
                 PROVE Invariant5'
-                <4>1 ASSUME NEW q \in Proc, NEW x \in Waves, NEW y \in Waves, Contains(x, commitWithRef'[q][y])
+                <4>1 ASSUME NEW q \in ProcessorSet, NEW x \in WaveSet, NEW y \in WaveSet, Contains(x, commitWithRef'[q][y])
                      PROVE IsPrefix(commitWithRef'[q][x], commitWithRef'[q][y])
                      <5>1 CASE p = q
                           <6>1 CASE x = w
@@ -283,7 +283,7 @@ LEMMA Invariant5correctness == Spec => []Invariant5
                                <7>2 CASE y = w
                                     <8>1 E # {} /\ Contains(x, commitWithRef[q][max(E)])
                                          BY <5>1,<7>2,<6>2,<4>1,<3>1,<2>1 DEF Contains,TypeOK, update_record
-                                    <8>2 max(E) \in Waves
+                                    <8>2 max(E) \in WaveSet
                                          BY <8>1,<3>1,maxIn
                                     <8>3 commitWithRef'[q][x] = commitWithRef[q][x]
                                          BY <6>2,<3>1,<4>1,<2>1 DEF TypeOK, update_record
@@ -298,9 +298,9 @@ LEMMA Invariant5correctness == Spec => []Invariant5
                           BY <5>2,<4>1,<3>1,<2>1 DEF TypeOK, Invariant5, update_record
                      <5> QED BY <5>1,<5>2 
                 <4> QED BY <4>1 DEF Invariant5
-           <3>2 ASSUME NEW p \in Proc, NEW w \in Waves, update_decidedRefWave(p, w)
+           <3>2 ASSUME NEW p \in ProcessorSet, NEW w \in WaveSet, update_decidedRefWave(p, w)
                 PROVE Invariant5'
-                <4>1 ASSUME NEW q \in Proc, NEW x \in Waves, NEW y \in Waves, Contains(x, commitWithRef'[q][y])
+                <4>1 ASSUME NEW q \in ProcessorSet, NEW x \in WaveSet, NEW y \in WaveSet, Contains(x, commitWithRef'[q][y])
                      PROVE IsPrefix(commitWithRef'[q][x], commitWithRef'[q][y])
                      BY <4>1,<3>2,<2>1 DEF TypeOK, Invariant5, update_decidedRefWave
                 <4> QED BY <4>1 DEF Invariant5
@@ -311,16 +311,16 @@ LEMMA Invariant5correctness == Spec => []Invariant5
       <2> QED BY <2>1, <2>2
  <1> QED BY <1>1, <1>2, Typecorrectness, Invariant4correctness, PTL DEF Spec
 
-\*\A p \in Proc, w \in Waves: record[p][w].exists = TRUE => commitWithRef[p][w] = IF record[p][w].edges = {} THEN <<w>> ELSE Append(commitWithRef[p][max(record[p][w].edges)], w) 
+\*\A p \in ProcessorSet, w \in WaveSet: record[p][w].exists = TRUE => commitWithRef[p][w] = IF record[p][w].edges = {} THEN <<w>> ELSE Append(commitWithRef[p][max(record[p][w].edges)], w) 
 LEMMA Invariant6correctness == Spec => []Invariant6
  <1>1 Init => Invariant6
       BY DEF Init, Invariant6
  <1>2 TypeOK /\ TypeOK' /\ Invariant6 /\ [Next]_vars /\ Invariant3 /\ Invariant3' => Invariant6'
       <2>1 ASSUME TypeOK, TypeOK', Next, Invariant6, Invariant3, Invariant3'
            PROVE Invariant6'
-           <3>1 ASSUME NEW p \in Proc, NEW w \in Waves, NEW E \in SUBSET(Waves), update_record(p, w, E)
+           <3>1 ASSUME NEW p \in ProcessorSet, NEW w \in WaveSet, NEW E \in SUBSET(WaveSet), update_record(p, w, E)
                 PROVE Invariant6'
-                <4>1 ASSUME NEW q \in Proc, NEW x \in Waves, record'[q][x].exists = TRUE
+                <4>1 ASSUME NEW q \in ProcessorSet, NEW x \in WaveSet, record'[q][x].exists = TRUE
                      PROVE commitWithRef'[q][x] = IF record'[q][x].edges = {} THEN <<x>> ELSE Append(commitWithRef'[q][max(record'[q][x].edges)], x)
                      <5>1 CASE q = p /\ x = w
                           <6>1 record'[q][x].edges = E
@@ -338,7 +338,7 @@ LEMMA Invariant6correctness == Spec => []Invariant6
                           <6>3 record'[q][x].edges # {} => commitWithRef'[q][max(record'[q][x].edges)] = commitWithRef[q][max(record[q][x].edges)]
                                <7>1 record[q][x].edges # {} => max(record[q][x].edges) # w \/ q # p
                                     <8>1 record[q][x].edges # {} => record[q][max(record[q][x].edges)].exists = TRUE
-                                         <9>1 record[q][x].edges \in SUBSET(Waves)
+                                         <9>1 record[q][x].edges \in SUBSET(WaveSet)
                                               BY <4>1,<2>1 DEF TypeOK
                                          <9>2 record[q][x].edges # {} => max(record[q][x].edges) \in record[q][x].edges
                                               BY <4>1,<2>1,<9>1, maxIn DEF TypeOK
@@ -348,9 +348,9 @@ LEMMA Invariant6correctness == Spec => []Invariant6
                           <6> QED BY <6>1,<6>2,<6>3,<4>1,<2>1 DEF Invariant6
                      <5> QED BY <5>1,<5>2
                 <4> QED BY <4>1 DEF Invariant6
-           <3>2 ASSUME NEW p \in Proc, NEW w \in Waves, update_decidedRefWave(p, w)
+           <3>2 ASSUME NEW p \in ProcessorSet, NEW w \in WaveSet, update_decidedRefWave(p, w)
                 PROVE Invariant6'
-                <4>1 ASSUME NEW q \in Proc, NEW x \in Waves, record'[q][x].exists = TRUE
+                <4>1 ASSUME NEW q \in ProcessorSet, NEW x \in WaveSet, record'[q][x].exists = TRUE
                      PROVE commitWithRef'[q][x] = IF record'[q][x].edges = {} THEN <<x>> ELSE Append(commitWithRef'[q][max(record'[q][x].edges)], x)
                      BY <4>1,<3>2,<2>1 DEF TypeOK, Invariant6, update_decidedRefWave
                 <4> QED BY <4>1 DEF Invariant6
@@ -368,9 +368,9 @@ LEMMA Invariant7correctness == Spec => []Invariant7
  <1>2 TypeOK /\ TypeOK' /\ Invariant7 /\ [Next]_vars /\ Invariant6 /\ Invariant3 => Invariant7'
       <2>1 ASSUME TypeOK, TypeOK', Next, Invariant7, Invariant6, Invariant3
            PROVE Invariant7'
-           <3>1 ASSUME NEW p \in Proc, NEW w \in Waves, NEW E \in SUBSET(Waves), update_record(p, w, E)
+           <3>1 ASSUME NEW p \in ProcessorSet, NEW w \in WaveSet, NEW E \in SUBSET(WaveSet), update_record(p, w, E)
                 PROVE Invariant7'
-                <4>1 ASSUME NEW q \in Proc, NEW r \in Proc, NEW x \in Waves, record'[q][x].exists = record'[r][x].exists
+                <4>1 ASSUME NEW q \in ProcessorSet, NEW r \in ProcessorSet, NEW x \in WaveSet, record'[q][x].exists = record'[r][x].exists
                      PROVE commitWithRef'[q][x] = commitWithRef'[r][x]
                      <5>1 CASE q = r
                           BY <5>1
@@ -416,9 +416,9 @@ LEMMA Invariant7correctness == Spec => []Invariant7
                           <6> QED BY <6>1,<6>2
                      <5> QED BY <5>1,<5>2
                 <4> QED BY <4>1 DEF Invariant7
-           <3>2 ASSUME NEW p \in Proc, NEW w \in Waves, update_decidedRefWave(p, w)
+           <3>2 ASSUME NEW p \in ProcessorSet, NEW w \in WaveSet, update_decidedRefWave(p, w)
                 PROVE Invariant7'
-                <4>1 ASSUME NEW q \in Proc, NEW r \in Proc, NEW x \in Waves, record'[q][x].exists = record'[r][x].exists
+                <4>1 ASSUME NEW q \in ProcessorSet, NEW r \in ProcessorSet, NEW x \in WaveSet, record'[q][x].exists = record'[r][x].exists
                      PROVE commitWithRef'[q][x] = commitWithRef'[r][x]
                      BY <4>1,<3>2,<2>1 DEF TypeOK, Invariant7, update_decidedRefWave
                 <4> QED BY <4>1 DEF Invariant7
@@ -436,9 +436,9 @@ LEMMA Invariant8correctness == Spec => []Invariant8
  <1>2 TypeOK /\ TypeOK' /\ Invariant8 /\ [Next]_vars /\ Invariant6' => Invariant8'
       <2>1 ASSUME TypeOK, TypeOK', Next, Invariant8, Invariant6'
            PROVE Invariant8'
-           <3>1 ASSUME NEW p \in Proc, NEW w \in Waves, NEW E \in SUBSET(Waves), update_record(p, w, E)
+           <3>1 ASSUME NEW p \in ProcessorSet, NEW w \in WaveSet, NEW E \in SUBSET(WaveSet), update_record(p, w, E)
                 PROVE Invariant8'
-                <4>1 ASSUME NEW q \in Proc, NEW x \in Waves, NEW z \in Waves, z >= x, record'[q][z].exists, \A y \in Waves : y > x /\ record'[q][y].exists => x \in record'[q][y].edges
+                <4>1 ASSUME NEW q \in ProcessorSet, NEW x \in WaveSet, NEW z \in WaveSet, z >= x, record'[q][z].exists, \A y \in WaveSet : y > x /\ record'[q][y].exists => x \in record'[q][y].edges
                      PROVE Contains(x, commitWithRef'[q][z]) 
                      <5>1 CASE x = z
                           <6>1 commitWithRef'[q][z] = IF record'[q][z].edges # {} THEN Append(commitWithRef'[q][max(record'[q][z].edges)], z) ELSE <<z>>
@@ -449,10 +449,10 @@ LEMMA Invariant8correctness == Spec => []Invariant8
                      <5>2 CASE x # z
                           <6>1 z > x
                                BY <5>2,<4>1
-                          <6>2 \A y \in Waves : y > x /\ record[q][y].exists => x \in record[q][y].edges
-                               <7>1 \A y \in Waves : y > x /\ (y # w \/ q # p) /\ record[q][y].exists => x \in record[q][y].edges
+                          <6>2 \A y \in WaveSet : y > x /\ record[q][y].exists => x \in record[q][y].edges
+                               <7>1 \A y \in WaveSet : y > x /\ (y # w \/ q # p) /\ record[q][y].exists => x \in record[q][y].edges
                                     BY <4>1,<3>1,<2>1 DEF TypeOK, update_record
-                               <7>2 \A y \in Waves : y > x /\ (y = w /\ q = p) => record[q][y].exists = FALSE
+                               <7>2 \A y \in WaveSet : y > x /\ (y = w /\ q = p) => record[q][y].exists = FALSE
                                     BY <4>1,<3>1,<2>1 DEF TypeOK, update_record
                                <7> QED BY <7>1,<7>2
                           <6>3 CASE p = q /\ w = z
@@ -476,7 +476,7 @@ LEMMA Invariant8correctness == Spec => []Invariant8
                           <6> QED BY <6>3,<6>4
                      <5> QED BY <5>1,<5>2
                 <4> QED BY <4>1 DEF Invariant8
-           <3>2 ASSUME NEW p \in Proc, NEW w \in Waves, update_decidedRefWave(p, w)
+           <3>2 ASSUME NEW p \in ProcessorSet, NEW w \in WaveSet, update_decidedRefWave(p, w)
                 PROVE Invariant8'
                 BY <3>2,<2>1 DEF TypeOK, Invariant8, update_decidedRefWave
            <3> QED BY <3>1,<3>2, <2>1 DEF Next
@@ -493,9 +493,9 @@ LEMMA Invariant9correctness == Spec => []Invariant9
  <1>2 TypeOK /\ TypeOK' /\ Invariant9 /\ [Next]_vars /\ Invariant8 /\ Invariant6 /\ Invariant3 => Invariant9'
       <2>1 ASSUME TypeOK, TypeOK', Next, Invariant8, Invariant6, Invariant3, Invariant9
            PROVE Invariant9'
-           <3>1 ASSUME NEW p \in Proc, NEW w \in Waves, NEW E \in SUBSET(Waves), update_record(p, w, E)
+           <3>1 ASSUME NEW p \in ProcessorSet, NEW w \in WaveSet, NEW E \in SUBSET(WaveSet), update_record(p, w, E)
                 PROVE Invariant9'
-                <4>1 ASSUME NEW q \in Proc, NEW r \in Proc, NEW x \in Waves, decidedRefWave'[q] # 0, x >= decidedRefWave'[q], record'[r][x].exists = TRUE
+                <4>1 ASSUME NEW q \in ProcessorSet, NEW r \in ProcessorSet, NEW x \in WaveSet, decidedRefWave'[q] # 0, x >= decidedRefWave'[q], record'[r][x].exists = TRUE
                      PROVE Contains(decidedRefWave'[q], commitWithRef'[r][x])
                      <5>1 decidedRefWave'[q] = decidedRefWave[q]
                           BY <4>1,<3>1,<2>1 DEF TypeOK, update_record
@@ -533,9 +533,9 @@ LEMMA Invariant9correctness == Spec => []Invariant9
                           <6> QED BY <6>1,<6>2
                      <5> QED BY <5>2,<5>3
                 <4> QED BY <4>1 DEF Invariant9
-           <3>2 ASSUME NEW p \in Proc, NEW w \in Waves, update_decidedRefWave(p, w)
+           <3>2 ASSUME NEW p \in ProcessorSet, NEW w \in WaveSet, update_decidedRefWave(p, w)
                 PROVE Invariant9'
-                <4>1 ASSUME NEW q \in Proc, NEW r \in Proc, NEW x \in Waves, decidedRefWave'[q] # 0, x >= decidedRefWave'[q], record'[r][x].exists = TRUE
+                <4>1 ASSUME NEW q \in ProcessorSet, NEW r \in ProcessorSet, NEW x \in WaveSet, decidedRefWave'[q] # 0, x >= decidedRefWave'[q], record'[r][x].exists = TRUE
                      PROVE Contains(decidedRefWave'[q], commitWithRef'[r][x])
                      <5>1 commitWithRef'[r][x] = commitWithRef[r][x] /\ record'[r][x].exists = record[r][x].exists
                           BY <4>1,<3>2,<2>1 DEF TypeOK,update_decidedRefWave
@@ -578,7 +578,7 @@ LEMMA Invariant9correctness == Spec => []Invariant9
                                         <9>1 w < x
                                              BY <7>2,<4>1,<6>1
                                         <9> QED BY <9>1,<5>3,<4>1,<3>2,<6>2,<4>1 DEF update_decidedRefWave
-                                   <8>2 record[r][x].edges \in SUBSET(Waves)
+                                   <8>2 record[r][x].edges \in SUBSET(WaveSet)
                                         BY <4>1,<2>1 DEF TypeOK
                                    <8>3 Contains(w, commitWithRef[r][max(record[r][x].edges)])     
                                         <9>1 max(record[r][x].edges) \in record[r][x].edges
@@ -587,7 +587,7 @@ LEMMA Invariant9correctness == Spec => []Invariant9
                                              BY <8>1, maxProperty,<3>1,<8>2 DEF max
                                         <9>3 record[r][max(record[r][x].edges)].exists = TRUE
                                              BY <4>1,<2>1,<9>1 DEF Invariant3
-                                        <9>4 \A z \in Waves : z >= w /\ record[r][z].exists = TRUE => Contains(w,commitWithRef[r][z])
+                                        <9>4 \A z \in WaveSet : z >= w /\ record[r][z].exists = TRUE => Contains(w,commitWithRef[r][z])
                                              BY <4>1,<3>2,<2>1 DEF Invariant8, update_decidedRefWave
                                         <9> QED BY <9>1,<9>2,<9>3,<9>4,<8>2
                                    <8>4 Contains(w, commitWithRef[r][max(record[r][x].edges)])  => Contains(w, Append(commitWithRef[r][max(record[r][x].edges)], x))
@@ -610,11 +610,11 @@ LEMMA Invariant10correctness == Spec => []Invariant10
  <1>2 Invariant1 /\ Invariant1' /\ Invariant4 /\ Invariant4' /\ Invariant7 /\ Invariant7' /\ Invariant5 /\ Invariant5'/\ Invariant9 /\ Invariant9' /\ TypeOK /\ TypeOK' /\ Invariant10 /\ [Next]_vars => Invariant10'
       <2>1 ASSUME Invariant9, Invariant9', TypeOK, TypeOK', Invariant10, [Next]_vars, Invariant1, Invariant1', Invariant4, Invariant4', Invariant7, Invariant7', Invariant5, Invariant5'
            PROVE Invariant10'
-           <3>1 ASSUME NEW p \in Proc, NEW q \in Proc, NEW w \in Waves, record'[p][w].exists = TRUE, w >= decidedRefWave'[q], decidedRefWave'[q] # 0
+           <3>1 ASSUME NEW p \in ProcessorSet, NEW q \in ProcessorSet, NEW w \in WaveSet, record'[p][w].exists = TRUE, w >= decidedRefWave'[q], decidedRefWave'[q] # 0
                 PROVE IsPrefix(commitWithRef'[q][decidedRefWave'[q]], commitWithRef'[p][w])
                 <4>1 Contains(decidedRefWave'[q], commitWithRef'[p][w]) 
                      BY <3>1,<2>1 DEF Invariant9
-                <4>2 decidedRefWave'[q] \in Waves
+                <4>2 decidedRefWave'[q] \in WaveSet
                      BY <3>1, <2>1 DEF TypeOK
                 <4>3 commitWithRef'[p][decidedRefWave'[q]] = commitWithRef'[q][decidedRefWave'[q]]
                      <5>1 record'[q][decidedRefWave'[q]].exists = TRUE
@@ -635,7 +635,7 @@ LEMMA ChainConsistancycorrectness == Spec => []ChainConsistancy
  <1>2 TypeOK /\ TypeOK' /\ Invariant10 /\ Invariant10' /\ Invariant1 /\ Invariant1'/\ Invariant2 /\ Invariant2' /\ [Next]_vars /\ ChainConsistancy => ChainConsistancy'
       <2>1 ASSUME TypeOK, TypeOK', Invariant10, Invariant10', [Next]_vars, ChainConsistancy, Invariant1, Invariant1', Invariant2, Invariant2'
            PROVE ChainConsistancy'
-           <3>1 ASSUME NEW p \in Proc, NEW q \in Proc, decidedRefWave'[p] <= decidedRefWave'[q]
+           <3>1 ASSUME NEW p \in ProcessorSet, NEW q \in ProcessorSet, decidedRefWave'[p] <= decidedRefWave'[q]
                 PROVE IsPrefix(leaderSeq'[p].current, leaderSeq'[q].current)
                 <4>1 CASE decidedRefWave'[p] = 0 /\ decidedRefWave'[q] = 0
                      <5>1 leaderSeq'[p].current = <<>> /\ leaderSeq'[q].current = <<>>
@@ -648,12 +648,12 @@ LEMMA ChainConsistancycorrectness == Spec => []ChainConsistancy
                 <4>3 CASE decidedRefWave'[p] # 0 /\ decidedRefWave'[q] # 0
                      <5>1 leaderSeq'[p].current = commitWithRef'[p][decidedRefWave'[p]] /\ leaderSeq'[q].current = commitWithRef'[q][decidedRefWave'[q]]
                           BY <4>3, <2>1, <3>1 DEF Invariant2
-                     <5>2 decidedRefWave'[q] \in Waves
+                     <5>2 decidedRefWave'[q] \in WaveSet
                           BY <2>1, <4>3 DEF TypeOK
                      <5>3 record'[q][decidedRefWave'[q]].exists = TRUE
                           BY <2>1, <3>1, <4>3 DEF Invariant1
                      <5> QED BY <5>1, <5>2,<5>3, <2>1, <3>1, <4>3 DEF Invariant10
-                <4> QED BY <3>1, <4>1,<4>2,<4>3, <2>1 DEF TypeOK, Waves
+                <4> QED BY <3>1, <4>1,<4>2,<4>3, <2>1 DEF TypeOK, WaveSet
            <3> QED BY <3>1 DEF ChainConsistancy
       <2> QED BY <2>1
  <1> QED BY <1>1, <1>2, Typecorrectness, Invariant10correctness, Invariant1correctness,Invariant2correctness, PTL DEF Spec
@@ -664,12 +664,12 @@ LEMMA ChainMonotonicitycorrectness == Spec => []ChainMonotonicity
  <1>2 TypeOK /\ TypeOK' /\ Invariant10 /\ Invariant10' /\ Invariant1 /\ Invariant1'/\ Invariant2 /\ Invariant2' /\ [Next]_vars /\ ChainMonotonicity => ChainMonotonicity'
       <2>1 ASSUME TypeOK, TypeOK', Invariant10, Invariant10', Next, ChainMonotonicity,  Invariant1, Invariant1', Invariant2, Invariant2'
            PROVE ChainMonotonicity'
-           <3>1 ASSUME NEW p \in Proc, NEW w \in Waves, NEW E \in SUBSET(Waves), update_record(p, w, E)
+           <3>1 ASSUME NEW p \in ProcessorSet, NEW w \in WaveSet, NEW E \in SUBSET(WaveSet), update_record(p, w, E)
                 PROVE ChainMonotonicity'
                 BY <3>1,<2>1 DEF ChainMonotonicity, update_record
-           <3>2 ASSUME NEW p \in Proc, NEW w \in Waves, update_decidedRefWave(p, w)
+           <3>2 ASSUME NEW p \in ProcessorSet, NEW w \in WaveSet, update_decidedRefWave(p, w)
                 PROVE ChainMonotonicity'
-                <4>1 ASSUME NEW q \in Proc
+                <4>1 ASSUME NEW q \in ProcessorSet
                      PROVE IsPrefix(leaderSeq'[q].last, leaderSeq'[q].current)
                      <5>1 CASE p = q
                           <6>1 leaderSeq'[q].current = commitWithRef[q][w]


### PR DESCRIPTION
Let's start renaming the objects in the TLA specification so that we provide some semantics in the naming convention. Instead of single letters, let's spell out the object name so that unaware readers can understand the semantics of the object better.

My suggestions:
- Add prefix "Num" to number quantities 
- Add suffix "Set" to simple sets
- Add suffix "Asm" for assumptions
